### PR TITLE
Fix shell script compatibility with macOS

### DIFF
--- a/build-src.sh
+++ b/build-src.sh
@@ -4,7 +4,7 @@
 # commit-db.rb list-valid nightly|GIT_DIR=/your/rust/dir/.git ./build-src.sh
 
 if [ $(uname) == 'Darwin' ]; then
-	alias tac='tail -f'
+	alias tac='tail -r'
 fi
 
 prompt_changes() {

--- a/edit-patches.sh
+++ b/edit-patches.sh
@@ -5,7 +5,7 @@
 
 prompt_changes() {
 	bold_arrow; echo "Editing $IO_COMMIT"
-	bold_arrow; echo -e "Remember to test your changes with: \e[1;36mcargo build\e[0m"
+	bold_arrow; echo -e "Remember to test your changes with: \033[1;36mcargo build\033[0m"
 
 	local MAIN_GIT_DIR="$GIT_DIR"
 	local GIT_DIR=./.git CORE_IO_COMMIT=$IO_COMMIT
@@ -18,9 +18,9 @@ prompt_changes() {
 	patch -s -p1 < $PATCH_DIR/$IO_COMMIT.patch
 	git commit -a -m "existing patch for $IO_COMMIT" > /dev/null
 
-	bold_arrow; echo -e "Applying patch from \e[1;36m$TMP_PATCH\e[0m"
+	bold_arrow; echo -e "Applying patch from \033[1;36m$TMP_PATCH\033[0m"
 	patch -p1 < $TMP_PATCH || true
-	bold_arrow; echo -e "Make your changes now (\e[1;36mctrl-D\e[0m when finished)"
+	bold_arrow; echo -e "Make your changes now (\033[1;36mctrl-D\033[0m when finished)"
 	bash_diff_loop "No changes were made"
 	bold_arrow; echo "Replacing $IO_COMMIT.patch with updated version"
 	git diff > $TMP_PATCH

--- a/functions.sh
+++ b/functions.sh
@@ -35,7 +35,7 @@ get_io_commits() {
 }
 
 get_patch_commits() {
-	find $PATCH_DIR -type f -printf %f\\n|cut -d. -f1
+	find $PATCH_DIR -type f|xargs -n 1 basename|cut -d. -f1
 }
 
 prepare_version() {
@@ -54,7 +54,7 @@ prepare_version() {
 }
 
 bold_arrow() {
-	echo -ne '\e[1;36m==> \e[0m'
+	echo -ne '\033[1;36m==> \033[0m'
 }
 
 custom_bashrc() {

--- a/functions.sh
+++ b/functions.sh
@@ -35,7 +35,7 @@ get_io_commits() {
 }
 
 get_patch_commits() {
-	find $PATCH_DIR -type f|xargs -n 1 basename|cut -d. -f1
+	find $PATCH_DIR -type f -print0|xargs -0 -n 1 basename|cut -d. -f1
 }
 
 prepare_version() {


### PR DESCRIPTION
This is a followup from #14 ... Finally getting around to submitting the PR to fix the shell scripts on macOS!

- `tac` does not exist on macOS, but `tail -f` is equivalent
- `stat` does not support `--printf`, but `-f` is equivalent
- `find` does not support `-printf`, but piping to `xargs -n 1 basename` is equivalent
- `echo -e` does not support `\e`, but `\033` is equivalent