### PR TITLE
Fix vectored I/O

### DIFF
--- a/patches/06da917b015a2eceac0e3cca22f9660edef25178.patch
+++ b/patches/06da917b015a2eceac0e3cca22f9660edef25178.patch
@@ -1401,16 +1401,16 @@ index b83f3fb..883fa30 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1906,15 +1855,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1907,6 +1856,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1914,7 +1864,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1418,7 +1418,7 @@ index b83f3fb..883fa30 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1953,13 +1896,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1953,13 +1903,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1432,7 +1432,7 @@ index b83f3fb..883fa30 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1975,14 +1916,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1975,14 +1923,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1449,7 +1449,7 @@ index b83f3fb..883fa30 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2007,13 +1948,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2007,13 +1955,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/115c8a1f095f99dab82da7ab1276c64747ed8fcc.patch
+++ b/patches/115c8a1f095f99dab82da7ab1276c64747ed8fcc.patch
@@ -311,20 +311,17 @@ diff --git a/cursor.rs b/cursor.rs
 index 577a115..8813aba 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,8 +1,9 @@
+@@ -1,7 +1,7 @@
  use io::prelude::*;
  
 -use core::convert::TryInto;
 -use cmp;
--use io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +#[cfg(feature="collections")] use core::convert::TryInto;
 +use core::cmp;
-+use io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use io::{IoVec, IoVecMut};
+ use io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
- /// [`Seek`] implementation.
-@@ -70,7 +71,6 @@ use io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
+@@ -70,7 +70,6 @@ use io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -332,7 +329,7 @@ index 577a115..8813aba 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -93,7 +93,6 @@ impl<T> Cursor<T> {
+@@ -93,7 +92,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -340,7 +337,7 @@ index 577a115..8813aba 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -111,7 +110,6 @@ impl<T> Cursor<T> {
+@@ -111,7 +109,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -348,7 +345,7 @@ index 577a115..8813aba 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -127,7 +125,6 @@ impl<T> Cursor<T> {
+@@ -127,7 +124,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -356,7 +353,7 @@ index 577a115..8813aba 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -146,7 +143,6 @@ impl<T> Cursor<T> {
+@@ -146,7 +142,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -364,7 +361,7 @@ index 577a115..8813aba 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -168,7 +164,6 @@ impl<T> Cursor<T> {
+@@ -168,7 +163,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -372,7 +369,7 @@ index 577a115..8813aba 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -188,11 +183,9 @@ impl<T> Cursor<T> {
+@@ -188,11 +182,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -384,7 +381,7 @@ index 577a115..8813aba 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -213,14 +206,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -213,10 +205,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -396,12 +393,7 @@ index 577a115..8813aba 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -235,7 +228,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -235,7 +226,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -410,7 +402,7 @@ index 577a115..8813aba 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -246,12 +239,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -246,12 +237,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -430,15 +422,7 @@ index 577a115..8813aba 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -263,6 +260,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -281,6 +279,7 @@ fn slice_write_vectored(
+@@ -281,6 +276,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -446,7 +430,7 @@ index 577a115..8813aba 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -307,6 +306,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -307,6 +303,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -454,7 +438,7 @@ index 577a115..8813aba 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -320,13 +320,13 @@ fn vec_write_vectored(
+@@ -320,7 +317,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -462,14 +446,7 @@ index 577a115..8813aba 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -335,12 +335,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -335,7 +331,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -478,13 +455,7 @@ index 577a115..8813aba 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -348,12 +349,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -348,7 +344,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -493,13 +464,7 @@ index 577a115..8813aba 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -361,13 +363,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -361,8 +357,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -510,12 +475,6 @@ index 577a115..8813aba 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index e9b4f60..31c0ff1 100644
 --- a/error.rs
@@ -835,7 +794,7 @@ diff --git a/impls.rs b/impls.rs
 index aa8db17..aaf1b00 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use cmp;
 -use io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -843,8 +802,8 @@ index aa8db17..aaf1b00 100644
 -use mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use io::{BufRead, IoVecMut, IoVec};
++use io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -857,14 +816,7 @@ index aa8db17..aaf1b00 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -878,7 +830,7 @@ index aa8db17..aaf1b00 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -886,12 +838,7 @@ index aa8db17..aaf1b00 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -905,7 +852,7 @@ index aa8db17..aaf1b00 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -914,14 +861,7 @@ index aa8db17..aaf1b00 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -935,7 +875,7 @@ index aa8db17..aaf1b00 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -944,12 +884,7 @@ index aa8db17..aaf1b00 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -964,7 +899,7 @@ index aa8db17..aaf1b00 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -172,7 +180,6 @@ impl<B: BufRead + ?Sized> BufRead for Box<B> {
+@@ -172,7 +176,6 @@ impl<B: BufRead + ?Sized> BufRead for Box<B> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -972,15 +907,7 @@ index aa8db17..aaf1b00 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -192,6 +199,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -231,6 +239,7 @@ impl Read for &[u8] {
+@@ -231,6 +234,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -988,7 +915,7 @@ index aa8db17..aaf1b00 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -240,7 +249,7 @@ impl Read for &[u8] {
+@@ -240,7 +244,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -997,7 +924,7 @@ index aa8db17..aaf1b00 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -254,7 +263,6 @@ impl BufRead for &[u8] {
+@@ -254,7 +258,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1005,15 +932,7 @@ index aa8db17..aaf1b00 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -265,6 +273,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -293,7 +302,7 @@ impl Write for &mut [u8] {
+@@ -293,7 +296,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1022,14 +941,6 @@ index aa8db17..aaf1b00 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -301,6 +310,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index 613ae7a..7fa4bb0 100644
 --- a/mod.rs
@@ -1063,9 +974,9 @@ index 613ae7a..7fa4bb0 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1141,16 +1052,15 @@ index 613ae7a..7fa4bb0 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -530,7 +519,7 @@ pub trait Read {
+@@ -530,7 +519,6 @@ pub trait Read {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `read`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          match bufs.iter_mut().find(|b| !b.is_empty()) {
              Some(buf) => self.read(buf),
-@@ -560,7 +549,6 @@ pub trait Read {
+@@ -560,7 +548,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1158,7 +1068,7 @@ index 613ae7a..7fa4bb0 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -613,7 +601,7 @@ pub trait Read {
+@@ -613,7 +600,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1167,7 +1077,7 @@ index 613ae7a..7fa4bb0 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -656,7 +644,7 @@ pub trait Read {
+@@ -656,7 +643,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1176,7 +1086,7 @@ index 613ae7a..7fa4bb0 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -719,7 +707,6 @@ pub trait Read {
+@@ -719,7 +706,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1184,7 +1094,7 @@ index 613ae7a..7fa4bb0 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -771,7 +758,6 @@ pub trait Read {
+@@ -771,7 +757,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1192,7 +1102,7 @@ index 613ae7a..7fa4bb0 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -808,7 +794,6 @@ pub trait Read {
+@@ -808,7 +793,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1200,7 +1110,7 @@ index 613ae7a..7fa4bb0 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -843,7 +828,6 @@ pub trait Read {
+@@ -843,7 +827,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1208,7 +1118,7 @@ index 613ae7a..7fa4bb0 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -879,42 +863,77 @@ pub trait Read {
+@@ -879,22 +862,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1218,10 +1128,8 @@ index 613ae7a..7fa4bb0 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1233,10 +1141,9 @@ index 613ae7a..7fa4bb0 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1260,23 +1167,15 @@ index 613ae7a..7fa4bb0 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -907,14 +920,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1289,41 +1188,31 @@ index 613ae7a..7fa4bb0 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -924,7 +943,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -924,7 +935,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -937,31 +956,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -937,11 +947,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -954,14 +962,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1336,11 +1225,10 @@ index 613ae7a..7fa4bb0 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -972,13 +991,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -972,13 +978,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1354,7 +1242,7 @@ index 613ae7a..7fa4bb0 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -992,21 +1009,18 @@ impl Initializer {
+@@ -992,21 +996,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1376,7 +1264,7 @@ index 613ae7a..7fa4bb0 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1049,7 +1063,6 @@ impl Initializer {
+@@ -1049,7 +1050,6 @@ impl Initializer {
  ///     Ok(())
  /// }
  /// ```
@@ -1384,7 +1272,7 @@ index 613ae7a..7fa4bb0 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1098,7 +1111,6 @@ pub trait Write {
+@@ -1098,7 +1098,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1392,16 +1280,15 @@ index 613ae7a..7fa4bb0 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1109,7 +1121,7 @@ pub trait Write {
+@@ -1109,7 +1108,6 @@ pub trait Write {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `write`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          match bufs.iter().find(|b| !b.is_empty()) {
              Some(buf) => self.write(buf),
-@@ -1140,7 +1152,6 @@ pub trait Write {
+@@ -1140,7 +1138,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1409,7 +1296,7 @@ index 613ae7a..7fa4bb0 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1173,7 +1184,6 @@ pub trait Write {
+@@ -1173,7 +1170,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1417,7 +1304,7 @@ index 613ae7a..7fa4bb0 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1225,7 +1235,6 @@ pub trait Write {
+@@ -1225,7 +1221,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1425,7 +1312,7 @@ index 613ae7a..7fa4bb0 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1281,7 +1290,6 @@ pub trait Write {
+@@ -1281,7 +1276,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1433,7 +1320,7 @@ index 613ae7a..7fa4bb0 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1311,7 +1319,6 @@ pub trait Write {
+@@ -1311,7 +1305,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1441,7 +1328,7 @@ index 613ae7a..7fa4bb0 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1327,7 +1334,6 @@ pub trait Seek {
+@@ -1327,7 +1320,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1449,7 +1336,7 @@ index 613ae7a..7fa4bb0 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  }
  
-@@ -1337,29 +1343,26 @@ pub trait Seek {
+@@ -1337,29 +1329,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1483,7 +1370,7 @@ index 613ae7a..7fa4bb0 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1439,7 +1442,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1439,7 +1428,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1492,7 +1379,7 @@ index 613ae7a..7fa4bb0 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1485,7 +1488,6 @@ pub trait BufRead: Read {
+@@ -1485,7 +1474,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1500,7 +1387,7 @@ index 613ae7a..7fa4bb0 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1507,7 +1509,6 @@ pub trait BufRead: Read {
+@@ -1507,7 +1495,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1508,7 +1395,7 @@ index 613ae7a..7fa4bb0 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1563,7 +1564,6 @@ pub trait BufRead: Read {
+@@ -1563,7 +1550,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1516,7 +1403,7 @@ index 613ae7a..7fa4bb0 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1622,7 +1622,6 @@ pub trait BufRead: Read {
+@@ -1622,7 +1608,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1524,7 +1411,7 @@ index 613ae7a..7fa4bb0 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1663,7 +1662,6 @@ pub trait BufRead: Read {
+@@ -1663,7 +1648,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1532,7 +1419,7 @@ index 613ae7a..7fa4bb0 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1702,7 +1700,6 @@ pub trait BufRead: Read {
+@@ -1702,7 +1686,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1540,7 +1427,7 @@ index 613ae7a..7fa4bb0 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1714,7 +1711,6 @@ pub trait BufRead: Read {
+@@ -1714,7 +1697,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1548,7 +1435,7 @@ index 613ae7a..7fa4bb0 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1740,7 +1736,6 @@ impl<T, U> Chain<T, U> {
+@@ -1740,7 +1722,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1556,7 +1443,7 @@ index 613ae7a..7fa4bb0 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1763,7 +1758,6 @@ impl<T, U> Chain<T, U> {
+@@ -1763,7 +1744,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1564,7 +1451,7 @@ index 613ae7a..7fa4bb0 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1790,13 +1784,11 @@ impl<T, U> Chain<T, U> {
+@@ -1790,13 +1770,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1578,7 +1465,7 @@ index 613ae7a..7fa4bb0 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1806,7 +1798,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1806,7 +1784,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1586,15 +1473,7 @@ index 613ae7a..7fa4bb0 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1818,6 +1809,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1838,7 +1830,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1838,7 +1815,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1603,7 +1482,7 @@ index 613ae7a..7fa4bb0 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1865,7 +1857,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1865,7 +1842,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1611,7 +1490,7 @@ index 613ae7a..7fa4bb0 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -1900,7 +1891,6 @@ impl<T> Take<T> {
+@@ -1900,7 +1876,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1619,7 +1498,7 @@ index 613ae7a..7fa4bb0 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -1926,7 +1916,6 @@ impl<T> Take<T> {
+@@ -1926,7 +1901,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1627,7 +1506,7 @@ index 613ae7a..7fa4bb0 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -1951,7 +1940,6 @@ impl<T> Take<T> {
+@@ -1951,7 +1925,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1635,7 +1514,7 @@ index 613ae7a..7fa4bb0 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -1976,7 +1964,6 @@ impl<T> Take<T> {
+@@ -1976,7 +1949,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1643,7 +1522,7 @@ index 613ae7a..7fa4bb0 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2005,13 +1992,11 @@ impl<T> Take<T> {
+@@ -2005,13 +1977,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1657,16 +1536,16 @@ index 613ae7a..7fa4bb0 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2028,15 +2013,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2029,6 +1999,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2036,7 +2007,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1674,7 +1553,7 @@ index 613ae7a..7fa4bb0 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2063,13 +2042,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2063,13 +2034,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1688,7 +1567,7 @@ index 613ae7a..7fa4bb0 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2093,14 +2070,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2093,14 +2062,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1705,7 +1584,7 @@ index 613ae7a..7fa4bb0 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2125,13 +2102,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2125,13 +2094,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1748,9 +1627,9 @@ index 5ce955e..c7d8697 100644
 -use io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use mem;
 +use core::fmt;
-+use io::{self, Read, Initializer, Write, ErrorKind};
++use io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use io::BufRead;
 +use core::mem;
-+#[cfg(feature="collections")] use io::{BufRead, IoVec, IoVecMut};
  
  /// Copies the entire contents of a reader into a writer.
  ///
@@ -1818,15 +1697,7 @@ index 5ce955e..c7d8697 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1834,7 +1705,7 @@ index 5ce955e..c7d8697 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1842,7 +1713,7 @@ index 5ce955e..c7d8697 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1853,12 +1724,7 @@ index 5ce955e..c7d8697 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/14ebca5c1986b55c39b5711c0cb33850afdc0a0c.patch
+++ b/patches/14ebca5c1986b55c39b5711c0cb33850afdc0a0c.patch
@@ -970,8 +970,8 @@ index 5137a94..da64ab7 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+use core::ptr;
 +use core::slice;
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1412,16 +1412,16 @@ index 5137a94..da64ab7 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1908,15 +1857,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1909,6 +1858,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1916,7 +1866,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1429,7 +1429,7 @@ index 5137a94..da64ab7 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1943,13 +1886,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -1943,13 +1893,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1443,7 +1443,7 @@ index 5137a94..da64ab7 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1973,14 +1914,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1973,14 +1921,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1460,7 +1460,7 @@ index 5137a94..da64ab7 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2005,13 +1946,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2005,13 +1953,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/1ed91951c3012e9aabb403d28b902c56cc143907.patch
+++ b/patches/1ed91951c3012e9aabb403d28b902c56cc143907.patch
@@ -1409,16 +1409,16 @@ index 076524e..0aa9ade 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1907,15 +1856,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1908,6 +1857,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1915,7 +1865,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1426,7 +1426,7 @@ index 076524e..0aa9ade 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1954,13 +1897,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1954,13 +1904,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1440,7 +1440,7 @@ index 076524e..0aa9ade 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1976,14 +1917,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1976,14 +1924,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1457,7 +1457,7 @@ index 076524e..0aa9ade 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2008,13 +1949,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2008,13 +1956,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/271eb8fc5a420280937bb1745f1e7aee7901ad26.patch
+++ b/patches/271eb8fc5a420280937bb1745f1e7aee7901ad26.patch
@@ -15,7 +15,7 @@ index bf406bb..067523b 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -311,21 +311,19 @@ diff --git a/cursor.rs b/cursor.rs
 index 247d45c..f13522d 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 247d45c..f13522d 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 247d45c..f13522d 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 247d45c..f13522d 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 247d45c..f13522d 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 247d45c..f13522d 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 247d45c..f13522d 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 247d45c..f13522d 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -222,14 +215,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -222,10 +214,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -244,7 +237,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -244,7 +235,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -255,12 +248,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -255,12 +246,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 247d45c..f13522d 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -272,6 +269,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -290,6 +288,7 @@ fn slice_write_vectored(
+@@ -290,6 +285,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 247d45c..f13522d 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -316,6 +315,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -316,6 +312,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 247d45c..f13522d 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -329,13 +329,13 @@ fn vec_write_vectored(
+@@ -329,7 +326,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -344,12 +344,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -344,7 +340,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -357,12 +358,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -357,7 +353,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -370,13 +372,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -370,8 +366,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 247d45c..f13522d 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index c29a68e..c94d8c5 100644
 --- a/error.rs
@@ -844,7 +804,7 @@ diff --git a/impls.rs b/impls.rs
 index 0eac96f..74d5f66 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -852,8 +812,8 @@ index 0eac96f..74d5f66 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -866,14 +826,7 @@ index 0eac96f..74d5f66 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -887,7 +840,7 @@ index 0eac96f..74d5f66 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -895,12 +848,7 @@ index 0eac96f..74d5f66 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -914,7 +862,7 @@ index 0eac96f..74d5f66 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -923,14 +871,7 @@ index 0eac96f..74d5f66 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -944,7 +885,7 @@ index 0eac96f..74d5f66 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -953,12 +894,7 @@ index 0eac96f..74d5f66 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -973,7 +909,7 @@ index 0eac96f..74d5f66 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -186,7 +194,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
+@@ -186,7 +190,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -981,15 +917,7 @@ index 0eac96f..74d5f66 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -206,6 +213,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -245,6 +253,7 @@ impl Read for &[u8] {
+@@ -245,6 +248,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -997,7 +925,7 @@ index 0eac96f..74d5f66 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -254,7 +263,7 @@ impl Read for &[u8] {
+@@ -254,7 +258,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -1006,7 +934,7 @@ index 0eac96f..74d5f66 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -268,7 +277,6 @@ impl BufRead for &[u8] {
+@@ -268,7 +272,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1014,15 +942,7 @@ index 0eac96f..74d5f66 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -279,6 +287,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -307,7 +316,7 @@ impl Write for &mut [u8] {
+@@ -307,7 +310,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1031,14 +951,6 @@ index 0eac96f..74d5f66 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -315,6 +324,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index 1ce66b9..fad199d 100644
 --- a/mod.rs
@@ -1072,9 +984,9 @@ index 1ce66b9..fad199d 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1134,23 +1046,7 @@ index 1ce66b9..fad199d 100644
  fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
                                                    buf: &mut Vec<u8>,
                                                    reservation_size: usize) -> Result<usize>
-@@ -390,6 +381,7 @@ fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
-     ret
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_read_vectored<F>(read: F, bufs: &mut [IoVecMut<'_>]) -> Result<usize>
- where
-     F: FnOnce(&mut [u8]) -> Result<usize>
-@@ -401,6 +393,7 @@ where
-     read(buf)
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_write_vectored<F>(write: F, bufs: &[IoVec<'_>]) -> Result<usize>
- where
-     F: FnOnce(&[u8]) -> Result<usize>
-@@ -484,7 +477,6 @@ where
+@@ -484,7 +475,6 @@ where
  /// [`BufReader`]: struct.BufReader.html
  /// [`&str`]: ../../std/primitive.str.html
  /// [slice]: ../../std/primitive.slice.html
@@ -1158,7 +1054,7 @@ index 1ce66b9..fad199d 100644
  #[doc(spotlight)]
  pub trait Read {
      /// Pull some bytes from this source into the specified buffer, returning
-@@ -543,7 +535,6 @@ pub trait Read {
+@@ -543,7 +533,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1166,16 +1062,15 @@ index 1ce66b9..fad199d 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -554,7 +545,7 @@ pub trait Read {
+@@ -554,7 +543,6 @@ pub trait Read {
      ///
      /// The default implementation calls `read` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          default_read_vectored(|b| self.read(b), bufs)
      }
-@@ -581,7 +572,6 @@ pub trait Read {
+@@ -581,7 +569,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1183,7 +1078,7 @@ index 1ce66b9..fad199d 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -634,7 +624,7 @@ pub trait Read {
+@@ -634,7 +621,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1192,7 +1087,7 @@ index 1ce66b9..fad199d 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -677,7 +667,7 @@ pub trait Read {
+@@ -677,7 +664,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1201,7 +1096,7 @@ index 1ce66b9..fad199d 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -740,7 +730,6 @@ pub trait Read {
+@@ -740,7 +727,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1104,7 @@ index 1ce66b9..fad199d 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -792,7 +781,6 @@ pub trait Read {
+@@ -792,7 +778,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1217,7 +1112,7 @@ index 1ce66b9..fad199d 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -829,7 +817,6 @@ pub trait Read {
+@@ -829,7 +814,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1225,7 +1120,7 @@ index 1ce66b9..fad199d 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -864,7 +851,6 @@ pub trait Read {
+@@ -864,7 +848,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1233,7 +1128,7 @@ index 1ce66b9..fad199d 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -900,42 +886,77 @@ pub trait Read {
+@@ -900,22 +883,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1243,10 +1138,8 @@ index 1ce66b9..fad199d 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1258,10 +1151,9 @@ index 1ce66b9..fad199d 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1285,23 +1177,15 @@ index 1ce66b9..fad199d 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -928,14 +941,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1314,41 +1198,31 @@ index 1ce66b9..fad199d 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -945,7 +966,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -945,7 +956,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -958,31 +979,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -958,11 +968,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -975,14 +983,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1361,11 +1235,10 @@ index 1ce66b9..fad199d 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -993,13 +1014,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -993,13 +999,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1379,7 +1252,7 @@ index 1ce66b9..fad199d 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -1013,21 +1032,18 @@ impl Initializer {
+@@ -1013,21 +1017,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1401,7 +1274,7 @@ index 1ce66b9..fad199d 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1081,7 +1097,6 @@ impl Initializer {
+@@ -1081,7 +1082,6 @@ impl Initializer {
  /// `write` in a loop until its entire input has been written.
  ///
  /// [`write_all`]: #method.write_all
@@ -1409,7 +1282,7 @@ index 1ce66b9..fad199d 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1130,7 +1145,6 @@ pub trait Write {
+@@ -1130,7 +1130,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1417,16 +1290,15 @@ index 1ce66b9..fad199d 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1141,7 +1155,7 @@ pub trait Write {
+@@ -1141,7 +1140,6 @@ pub trait Write {
      ///
      /// The default implementation calls `write` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          default_write_vectored(|b| self.write(b), bufs)
      }
-@@ -1169,7 +1183,6 @@ pub trait Write {
+@@ -1169,7 +1167,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1306,7 @@ index 1ce66b9..fad199d 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1202,7 +1215,6 @@ pub trait Write {
+@@ -1202,7 +1199,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1442,7 +1314,7 @@ index 1ce66b9..fad199d 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1254,7 +1266,6 @@ pub trait Write {
+@@ -1254,7 +1250,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1450,7 +1322,7 @@ index 1ce66b9..fad199d 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1310,7 +1321,6 @@ pub trait Write {
+@@ -1310,7 +1305,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1458,7 +1330,7 @@ index 1ce66b9..fad199d 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1340,7 +1350,6 @@ pub trait Write {
+@@ -1340,7 +1334,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1466,7 +1338,7 @@ index 1ce66b9..fad199d 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1356,7 +1365,6 @@ pub trait Seek {
+@@ -1356,7 +1349,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1474,7 +1346,7 @@ index 1ce66b9..fad199d 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  
      /// Returns the length of this stream (in bytes).
-@@ -1394,7 +1402,6 @@ pub trait Seek {
+@@ -1394,7 +1386,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1482,7 +1354,7 @@ index 1ce66b9..fad199d 100644
      fn stream_len(&mut self) -> Result<u64> {
          let old_pos = self.stream_position()?;
          let len = self.seek(SeekFrom::End(0))?;
-@@ -1433,7 +1440,6 @@ pub trait Seek {
+@@ -1433,7 +1424,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1490,7 +1362,7 @@ index 1ce66b9..fad199d 100644
      fn stream_position(&mut self) -> Result<u64> {
          self.seek(SeekFrom::Current(0))
      }
-@@ -1445,29 +1451,26 @@ pub trait Seek {
+@@ -1445,29 +1435,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1524,7 +1396,7 @@ index 1ce66b9..fad199d 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1547,7 +1550,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1547,7 +1534,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1533,7 +1405,7 @@ index 1ce66b9..fad199d 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1593,7 +1596,6 @@ pub trait BufRead: Read {
+@@ -1593,7 +1580,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1541,7 +1413,7 @@ index 1ce66b9..fad199d 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1615,7 +1617,6 @@ pub trait BufRead: Read {
+@@ -1615,7 +1601,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1549,7 +1421,7 @@ index 1ce66b9..fad199d 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1671,7 +1672,6 @@ pub trait BufRead: Read {
+@@ -1671,7 +1656,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1557,7 +1429,7 @@ index 1ce66b9..fad199d 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1730,7 +1730,6 @@ pub trait BufRead: Read {
+@@ -1730,7 +1714,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1565,7 +1437,7 @@ index 1ce66b9..fad199d 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1771,7 +1770,6 @@ pub trait BufRead: Read {
+@@ -1771,7 +1754,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1573,7 +1445,7 @@ index 1ce66b9..fad199d 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1810,7 +1808,6 @@ pub trait BufRead: Read {
+@@ -1810,7 +1792,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1581,7 +1453,7 @@ index 1ce66b9..fad199d 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1822,7 +1819,6 @@ pub trait BufRead: Read {
+@@ -1822,7 +1803,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1589,7 +1461,7 @@ index 1ce66b9..fad199d 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1848,7 +1844,6 @@ impl<T, U> Chain<T, U> {
+@@ -1848,7 +1828,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1597,7 +1469,7 @@ index 1ce66b9..fad199d 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1871,7 +1866,6 @@ impl<T, U> Chain<T, U> {
+@@ -1871,7 +1850,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1605,7 +1477,7 @@ index 1ce66b9..fad199d 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1898,13 +1892,11 @@ impl<T, U> Chain<T, U> {
+@@ -1898,13 +1876,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1619,7 +1491,7 @@ index 1ce66b9..fad199d 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1914,7 +1906,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1914,7 +1890,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1627,15 +1499,7 @@ index 1ce66b9..fad199d 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1926,6 +1917,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1946,7 +1938,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1946,7 +1921,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1644,7 +1508,7 @@ index 1ce66b9..fad199d 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1973,7 +1965,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1973,7 +1948,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1652,7 +1516,7 @@ index 1ce66b9..fad199d 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -2008,7 +1999,6 @@ impl<T> Take<T> {
+@@ -2008,7 +1982,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1660,7 +1524,7 @@ index 1ce66b9..fad199d 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -2034,7 +2024,6 @@ impl<T> Take<T> {
+@@ -2034,7 +2007,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1668,7 +1532,7 @@ index 1ce66b9..fad199d 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -2059,7 +2048,6 @@ impl<T> Take<T> {
+@@ -2059,7 +2031,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1676,7 +1540,7 @@ index 1ce66b9..fad199d 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -2084,7 +2072,6 @@ impl<T> Take<T> {
+@@ -2084,7 +2055,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1684,7 +1548,7 @@ index 1ce66b9..fad199d 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2113,13 +2100,11 @@ impl<T> Take<T> {
+@@ -2113,13 +2083,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1698,16 +1562,16 @@ index 1ce66b9..fad199d 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2136,15 +2121,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2137,6 +2105,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2144,7 +2113,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1715,7 +1579,7 @@ index 1ce66b9..fad199d 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2171,13 +2150,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2171,13 +2140,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1729,7 +1593,7 @@ index 1ce66b9..fad199d 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2201,14 +2178,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2201,14 +2168,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1746,7 +1610,7 @@ index 1ce66b9..fad199d 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2233,13 +2210,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2233,13 +2200,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1789,8 +1653,8 @@ index d2638be..1296fe1 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1859,15 +1723,7 @@ index d2638be..1296fe1 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1875,7 +1731,7 @@ index d2638be..1296fe1 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1883,7 +1739,7 @@ index d2638be..1296fe1 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1894,12 +1750,7 @@ index d2638be..1296fe1 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/27c3631d826aaad964f42ee94f26f9e80d658e3f.patch
+++ b/patches/27c3631d826aaad964f42ee94f26f9e80d658e3f.patch
@@ -1410,16 +1410,16 @@ index dc97701..6ea0b47 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1907,15 +1856,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1908,6 +1857,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1915,7 +1865,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1427,7 +1427,7 @@ index dc97701..6ea0b47 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1954,13 +1897,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1954,13 +1904,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1441,7 +1441,7 @@ index dc97701..6ea0b47 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1976,14 +1917,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1976,14 +1924,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1458,7 +1458,7 @@ index dc97701..6ea0b47 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2008,13 +1949,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2008,13 +1956,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/27c8dfddac4c69a6fd399abe537e1007306c58cf.patch
+++ b/patches/27c8dfddac4c69a6fd399abe537e1007306c58cf.patch
@@ -962,8 +962,8 @@ index 28a6fbd..2f5ae43 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+use core::ptr;
 +use core::slice;
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1404,16 +1404,16 @@ index 28a6fbd..2f5ae43 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1898,15 +1847,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1899,6 +1848,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1906,7 +1856,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1421,7 +1421,7 @@ index 28a6fbd..2f5ae43 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1933,13 +1876,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -1933,13 +1883,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1435,7 +1435,7 @@ index 28a6fbd..2f5ae43 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1963,14 +1904,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1963,14 +1911,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1452,7 +1452,7 @@ index 28a6fbd..2f5ae43 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -1995,13 +1936,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -1995,13 +1943,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1496,8 +1496,8 @@ index 8df961a..2b08122 100644
 -use mem;
 +use core::fmt;
 +use io::{self, Read, Initializer, Write, ErrorKind};
-+use core::mem;
 +#[cfg(feature="collections")] use io::BufRead;
++use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
  ///

--- a/patches/2a663555ddf36f6b041445894a8c175cd1bc718c.patch
+++ b/patches/2a663555ddf36f6b041445894a8c175cd1bc718c.patch
@@ -962,8 +962,8 @@ index 040669b..ee4d22c 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+use core::ptr;
 +use core::slice;
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1404,16 +1404,16 @@ index 040669b..ee4d22c 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1898,15 +1847,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1899,6 +1848,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1906,7 +1856,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1421,7 +1421,7 @@ index 040669b..ee4d22c 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1933,13 +1876,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -1933,13 +1883,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1435,7 +1435,7 @@ index 040669b..ee4d22c 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1963,14 +1904,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1963,14 +1911,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1452,7 +1452,7 @@ index 040669b..ee4d22c 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -1995,13 +1936,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -1995,13 +1943,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1496,8 +1496,8 @@ index 8df961a..2b08122 100644
 -use mem;
 +use core::fmt;
 +use io::{self, Read, Initializer, Write, ErrorKind};
-+use core::mem;
 +#[cfg(feature="collections")] use io::BufRead;
++use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
  ///

--- a/patches/31bec788f46c73ab14c72868dc6141141320a058.patch
+++ b/patches/31bec788f46c73ab14c72868dc6141141320a058.patch
@@ -1408,16 +1408,16 @@ index b83f3fb..883fa30 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1906,15 +1855,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1907,6 +1856,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1914,7 +1864,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1425,7 +1425,7 @@ index b83f3fb..883fa30 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1953,13 +1896,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1953,13 +1903,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1439,7 +1439,7 @@ index b83f3fb..883fa30 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1975,14 +1916,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1975,14 +1923,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1456,7 +1456,7 @@ index b83f3fb..883fa30 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2007,13 +1948,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2007,13 +1955,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/379c380a60e7b3adb6c6f595222cbfa2d9160a20.patch
+++ b/patches/379c380a60e7b3adb6c6f595222cbfa2d9160a20.patch
@@ -15,7 +15,7 @@ index 3370a44..f1f0573 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -311,21 +311,19 @@ diff --git a/cursor.rs b/cursor.rs
 index 247d45c..f13522d 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 247d45c..f13522d 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 247d45c..f13522d 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 247d45c..f13522d 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 247d45c..f13522d 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 247d45c..f13522d 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 247d45c..f13522d 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 247d45c..f13522d 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -222,14 +215,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -222,10 +214,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -244,7 +237,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -244,7 +235,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -255,12 +248,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -255,12 +246,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 247d45c..f13522d 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -272,6 +269,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -290,6 +288,7 @@ fn slice_write_vectored(
+@@ -290,6 +285,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 247d45c..f13522d 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -316,6 +315,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -316,6 +312,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 247d45c..f13522d 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -329,13 +329,13 @@ fn vec_write_vectored(
+@@ -329,7 +326,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -344,12 +344,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -344,7 +340,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -357,12 +358,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -357,7 +353,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -370,13 +372,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -370,8 +366,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 247d45c..f13522d 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index c29a68e..c94d8c5 100644
 --- a/error.rs
@@ -844,7 +804,7 @@ diff --git a/impls.rs b/impls.rs
 index 0eac96f..74d5f66 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -852,8 +812,8 @@ index 0eac96f..74d5f66 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -866,14 +826,7 @@ index 0eac96f..74d5f66 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -887,7 +840,7 @@ index 0eac96f..74d5f66 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -895,12 +848,7 @@ index 0eac96f..74d5f66 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -914,7 +862,7 @@ index 0eac96f..74d5f66 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -923,14 +871,7 @@ index 0eac96f..74d5f66 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -944,7 +885,7 @@ index 0eac96f..74d5f66 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -953,12 +894,7 @@ index 0eac96f..74d5f66 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -973,7 +909,7 @@ index 0eac96f..74d5f66 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -186,7 +194,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
+@@ -186,7 +190,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -981,15 +917,7 @@ index 0eac96f..74d5f66 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -206,6 +213,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -245,6 +253,7 @@ impl Read for &[u8] {
+@@ -245,6 +248,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -997,7 +925,7 @@ index 0eac96f..74d5f66 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -254,7 +263,7 @@ impl Read for &[u8] {
+@@ -254,7 +258,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -1006,7 +934,7 @@ index 0eac96f..74d5f66 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -268,7 +277,6 @@ impl BufRead for &[u8] {
+@@ -268,7 +272,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1014,15 +942,7 @@ index 0eac96f..74d5f66 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -279,6 +287,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -307,7 +316,7 @@ impl Write for &mut [u8] {
+@@ -307,7 +310,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1031,16 +951,8 @@ index 0eac96f..74d5f66 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -315,6 +324,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
-index 1ce66b9..fad199d 100644
+index 1ce66b9..6e83804 100644
 --- a/mod.rs
 +++ b/mod.rs
 @@ -257,50 +257,38 @@
@@ -1072,9 +984,9 @@ index 1ce66b9..fad199d 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1134,23 +1046,7 @@ index 1ce66b9..fad199d 100644
  fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
                                                    buf: &mut Vec<u8>,
                                                    reservation_size: usize) -> Result<usize>
-@@ -390,6 +381,7 @@ fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
-     ret
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_read_vectored<F>(read: F, bufs: &mut [IoVecMut<'_>]) -> Result<usize>
- where
-     F: FnOnce(&mut [u8]) -> Result<usize>
-@@ -401,6 +393,7 @@ where
-     read(buf)
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_write_vectored<F>(write: F, bufs: &[IoVec<'_>]) -> Result<usize>
- where
-     F: FnOnce(&[u8]) -> Result<usize>
-@@ -484,7 +477,6 @@ where
+@@ -484,7 +475,6 @@ where
  /// [`BufReader`]: struct.BufReader.html
  /// [`&str`]: ../../std/primitive.str.html
  /// [slice]: ../../std/primitive.slice.html
@@ -1158,7 +1054,7 @@ index 1ce66b9..fad199d 100644
  #[doc(spotlight)]
  pub trait Read {
      /// Pull some bytes from this source into the specified buffer, returning
-@@ -543,7 +535,6 @@ pub trait Read {
+@@ -543,7 +533,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1166,16 +1062,15 @@ index 1ce66b9..fad199d 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -554,7 +545,7 @@ pub trait Read {
+@@ -554,7 +543,6 @@ pub trait Read {
      ///
      /// The default implementation calls `read` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          default_read_vectored(|b| self.read(b), bufs)
      }
-@@ -581,7 +572,6 @@ pub trait Read {
+@@ -581,7 +569,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1183,7 +1078,7 @@ index 1ce66b9..fad199d 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -634,7 +624,7 @@ pub trait Read {
+@@ -634,7 +621,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1192,7 +1087,7 @@ index 1ce66b9..fad199d 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -677,7 +667,7 @@ pub trait Read {
+@@ -677,7 +664,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1201,7 +1096,7 @@ index 1ce66b9..fad199d 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -740,7 +730,6 @@ pub trait Read {
+@@ -740,7 +727,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1104,7 @@ index 1ce66b9..fad199d 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -792,7 +781,6 @@ pub trait Read {
+@@ -792,7 +778,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1217,7 +1112,7 @@ index 1ce66b9..fad199d 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -829,7 +817,6 @@ pub trait Read {
+@@ -829,7 +814,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1225,7 +1120,7 @@ index 1ce66b9..fad199d 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -864,7 +851,6 @@ pub trait Read {
+@@ -864,7 +848,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1233,7 +1128,7 @@ index 1ce66b9..fad199d 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -900,42 +886,77 @@ pub trait Read {
+@@ -900,22 +883,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1243,10 +1138,8 @@ index 1ce66b9..fad199d 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1258,10 +1151,9 @@ index 1ce66b9..fad199d 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1285,23 +1177,15 @@ index 1ce66b9..fad199d 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -928,14 +941,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1314,41 +1198,31 @@ index 1ce66b9..fad199d 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -945,7 +966,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -945,7 +956,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -958,31 +979,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -958,11 +968,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -975,14 +983,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1361,11 +1235,10 @@ index 1ce66b9..fad199d 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -993,13 +1014,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -993,13 +999,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1379,7 +1252,7 @@ index 1ce66b9..fad199d 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -1013,21 +1032,18 @@ impl Initializer {
+@@ -1013,21 +1017,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1401,7 +1274,7 @@ index 1ce66b9..fad199d 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1081,7 +1097,6 @@ impl Initializer {
+@@ -1081,7 +1082,6 @@ impl Initializer {
  /// `write` in a loop until its entire input has been written.
  ///
  /// [`write_all`]: #method.write_all
@@ -1409,7 +1282,7 @@ index 1ce66b9..fad199d 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1130,7 +1145,6 @@ pub trait Write {
+@@ -1130,7 +1130,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1417,16 +1290,15 @@ index 1ce66b9..fad199d 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1141,7 +1155,7 @@ pub trait Write {
+@@ -1141,7 +1140,6 @@ pub trait Write {
      ///
      /// The default implementation calls `write` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          default_write_vectored(|b| self.write(b), bufs)
      }
-@@ -1169,7 +1183,6 @@ pub trait Write {
+@@ -1169,7 +1167,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1306,7 @@ index 1ce66b9..fad199d 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1202,7 +1215,6 @@ pub trait Write {
+@@ -1202,7 +1199,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1442,7 +1314,7 @@ index 1ce66b9..fad199d 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1254,7 +1266,6 @@ pub trait Write {
+@@ -1254,7 +1250,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1450,7 +1322,7 @@ index 1ce66b9..fad199d 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1310,7 +1321,6 @@ pub trait Write {
+@@ -1310,7 +1305,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1458,7 +1330,7 @@ index 1ce66b9..fad199d 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1340,7 +1350,6 @@ pub trait Write {
+@@ -1340,7 +1334,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1466,7 +1338,7 @@ index 1ce66b9..fad199d 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1356,7 +1365,6 @@ pub trait Seek {
+@@ -1356,7 +1349,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1474,7 +1346,7 @@ index 1ce66b9..fad199d 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  
      /// Returns the length of this stream (in bytes).
-@@ -1394,7 +1402,6 @@ pub trait Seek {
+@@ -1394,7 +1386,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1482,7 +1354,7 @@ index 1ce66b9..fad199d 100644
      fn stream_len(&mut self) -> Result<u64> {
          let old_pos = self.stream_position()?;
          let len = self.seek(SeekFrom::End(0))?;
-@@ -1433,7 +1440,6 @@ pub trait Seek {
+@@ -1433,7 +1424,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1490,7 +1362,7 @@ index 1ce66b9..fad199d 100644
      fn stream_position(&mut self) -> Result<u64> {
          self.seek(SeekFrom::Current(0))
      }
-@@ -1445,29 +1451,26 @@ pub trait Seek {
+@@ -1445,29 +1435,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1524,7 +1396,7 @@ index 1ce66b9..fad199d 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1547,7 +1550,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1547,7 +1534,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1533,7 +1405,7 @@ index 1ce66b9..fad199d 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1593,7 +1596,6 @@ pub trait BufRead: Read {
+@@ -1593,7 +1580,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1541,7 +1413,7 @@ index 1ce66b9..fad199d 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1615,7 +1617,6 @@ pub trait BufRead: Read {
+@@ -1615,7 +1601,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1549,7 +1421,7 @@ index 1ce66b9..fad199d 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1671,7 +1672,6 @@ pub trait BufRead: Read {
+@@ -1671,7 +1656,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1557,7 +1429,7 @@ index 1ce66b9..fad199d 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1730,7 +1730,6 @@ pub trait BufRead: Read {
+@@ -1730,7 +1714,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1565,7 +1437,7 @@ index 1ce66b9..fad199d 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1771,7 +1770,6 @@ pub trait BufRead: Read {
+@@ -1771,7 +1754,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1573,7 +1445,7 @@ index 1ce66b9..fad199d 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1810,7 +1808,6 @@ pub trait BufRead: Read {
+@@ -1810,7 +1792,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1581,7 +1453,7 @@ index 1ce66b9..fad199d 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1822,7 +1819,6 @@ pub trait BufRead: Read {
+@@ -1822,7 +1803,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1589,7 +1461,7 @@ index 1ce66b9..fad199d 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1848,7 +1844,6 @@ impl<T, U> Chain<T, U> {
+@@ -1848,7 +1828,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1597,7 +1469,7 @@ index 1ce66b9..fad199d 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1871,7 +1866,6 @@ impl<T, U> Chain<T, U> {
+@@ -1871,7 +1850,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1605,7 +1477,7 @@ index 1ce66b9..fad199d 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1898,13 +1892,11 @@ impl<T, U> Chain<T, U> {
+@@ -1898,13 +1876,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1619,7 +1491,7 @@ index 1ce66b9..fad199d 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1914,7 +1906,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1914,7 +1890,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1627,15 +1499,7 @@ index 1ce66b9..fad199d 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1926,6 +1917,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1946,7 +1938,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1946,7 +1921,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1644,7 +1508,7 @@ index 1ce66b9..fad199d 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1973,7 +1965,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1973,7 +1948,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1652,7 +1516,7 @@ index 1ce66b9..fad199d 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -2008,7 +1999,6 @@ impl<T> Take<T> {
+@@ -2008,7 +1982,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1660,7 +1524,7 @@ index 1ce66b9..fad199d 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -2034,7 +2024,6 @@ impl<T> Take<T> {
+@@ -2034,7 +2007,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1668,7 +1532,7 @@ index 1ce66b9..fad199d 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -2059,7 +2048,6 @@ impl<T> Take<T> {
+@@ -2059,7 +2031,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1676,7 +1540,7 @@ index 1ce66b9..fad199d 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -2084,7 +2072,6 @@ impl<T> Take<T> {
+@@ -2084,7 +2055,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1684,7 +1548,7 @@ index 1ce66b9..fad199d 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2113,13 +2100,11 @@ impl<T> Take<T> {
+@@ -2113,13 +2083,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1698,16 +1562,16 @@ index 1ce66b9..fad199d 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2136,15 +2121,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2137,6 +2105,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2144,7 +2113,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1715,7 +1579,7 @@ index 1ce66b9..fad199d 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2171,13 +2150,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2171,13 +2140,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1729,7 +1593,7 @@ index 1ce66b9..fad199d 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2201,14 +2178,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2201,14 +2168,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1746,7 +1610,7 @@ index 1ce66b9..fad199d 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2233,13 +2210,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2233,13 +2200,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1789,8 +1653,8 @@ index d2638be..1296fe1 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1859,15 +1723,7 @@ index d2638be..1296fe1 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1875,7 +1731,7 @@ index d2638be..1296fe1 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1883,7 +1739,7 @@ index d2638be..1296fe1 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1894,12 +1750,7 @@ index d2638be..1296fe1 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/3c9e884dd3bf93b1516d3b5858072b7659c4cfba.patch
+++ b/patches/3c9e884dd3bf93b1516d3b5858072b7659c4cfba.patch
@@ -1401,16 +1401,16 @@ index 278ee79..ebe2495 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1907,15 +1856,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1908,6 +1857,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1915,7 +1865,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1418,7 +1418,7 @@ index 278ee79..ebe2495 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1954,13 +1897,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1954,13 +1904,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1432,7 +1432,7 @@ index 278ee79..ebe2495 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1976,14 +1917,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1976,14 +1924,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1449,7 +1449,7 @@ index 278ee79..ebe2495 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2008,13 +1949,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2008,13 +1956,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/472ca7159812f8c360697f63454ee7bda1e02570.patch
+++ b/patches/472ca7159812f8c360697f63454ee7bda1e02570.patch
@@ -1401,16 +1401,16 @@ index b83f3fb..883fa30 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1906,15 +1855,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1907,6 +1856,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1914,7 +1864,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1418,7 +1418,7 @@ index b83f3fb..883fa30 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1953,13 +1896,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1953,13 +1903,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1432,7 +1432,7 @@ index b83f3fb..883fa30 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1975,14 +1916,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1975,14 +1923,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1449,7 +1449,7 @@ index b83f3fb..883fa30 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2007,13 +1948,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2007,13 +1955,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/5285d35b49e1e8976f2a8d9d2e6f5bd1324016d3.patch
+++ b/patches/5285d35b49e1e8976f2a8d9d2e6f5bd1324016d3.patch
@@ -1401,16 +1401,16 @@ index e263db2..2176464 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1907,15 +1856,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1908,6 +1857,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1915,7 +1865,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1418,7 +1418,7 @@ index e263db2..2176464 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1954,13 +1897,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1954,13 +1904,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1432,7 +1432,7 @@ index e263db2..2176464 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1976,14 +1917,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1976,14 +1924,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1449,7 +1449,7 @@ index e263db2..2176464 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2008,13 +1949,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2008,13 +1956,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/654c5788aa2130acfc89a0883952c6de4bddac95.patch
+++ b/patches/654c5788aa2130acfc89a0883952c6de4bddac95.patch
@@ -1401,16 +1401,16 @@ index b83f3fb..883fa30 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1906,15 +1855,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1907,6 +1856,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1914,7 +1864,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1418,7 +1418,7 @@ index b83f3fb..883fa30 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1953,13 +1896,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1953,13 +1903,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1432,7 +1432,7 @@ index b83f3fb..883fa30 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1975,14 +1916,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1975,14 +1923,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1449,7 +1449,7 @@ index b83f3fb..883fa30 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2007,13 +1948,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2007,13 +1955,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/71120ef1e5cb885ee45e6148970db6ce93ce1aca.patch
+++ b/patches/71120ef1e5cb885ee45e6148970db6ce93ce1aca.patch
@@ -1401,16 +1401,16 @@ index b83f3fb..883fa30 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1906,15 +1855,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1907,6 +1856,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1914,7 +1864,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1418,7 +1418,7 @@ index b83f3fb..883fa30 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1953,13 +1896,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1953,13 +1903,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1432,7 +1432,7 @@ index b83f3fb..883fa30 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1975,14 +1916,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1975,14 +1923,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1449,7 +1449,7 @@ index b83f3fb..883fa30 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2007,13 +1948,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2007,13 +1955,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/89573b3c8b629507130b1ec8beeaf550fdc0e046.patch
+++ b/patches/89573b3c8b629507130b1ec8beeaf550fdc0e046.patch
@@ -15,7 +15,7 @@ index 4668e3e..4c125bd 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -308,24 +308,22 @@ index 4668e3e..4c125bd 100644
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt.debug_struct("LineWriter")
 diff --git a/cursor.rs b/cursor.rs
-index 247d45c..f13522d 100644
+index 247d45c..d47179e 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 247d45c..f13522d 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 247d45c..f13522d 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 247d45c..f13522d 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 247d45c..f13522d 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 247d45c..f13522d 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 247d45c..f13522d 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 247d45c..f13522d 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -222,14 +215,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -222,10 +214,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -244,7 +237,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -244,7 +235,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -255,12 +248,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -255,12 +246,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 247d45c..f13522d 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -272,6 +269,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -290,6 +288,7 @@ fn slice_write_vectored(
+@@ -290,6 +285,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 247d45c..f13522d 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -316,6 +315,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -316,6 +312,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 247d45c..f13522d 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -329,13 +329,13 @@ fn vec_write_vectored(
+@@ -329,7 +326,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -344,12 +344,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -344,7 +340,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -357,12 +358,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -357,7 +353,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -370,13 +372,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -370,8 +366,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 247d45c..f13522d 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index 614b791..e4ce8b5 100644
 --- a/error.rs
@@ -844,7 +804,7 @@ diff --git a/impls.rs b/impls.rs
 index b286e40..7472d9c 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -852,8 +812,8 @@ index b286e40..7472d9c 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -866,14 +826,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -887,7 +840,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -895,12 +848,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -914,7 +862,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -923,14 +871,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -944,7 +885,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -953,12 +894,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -973,7 +909,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -186,7 +194,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
+@@ -186,7 +190,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -981,15 +917,7 @@ index b286e40..7472d9c 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -206,6 +213,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -245,6 +253,7 @@ impl Read for &[u8] {
+@@ -245,6 +248,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -997,7 +925,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -254,7 +263,7 @@ impl Read for &[u8] {
+@@ -254,7 +258,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -1006,7 +934,7 @@ index b286e40..7472d9c 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -268,7 +277,6 @@ impl BufRead for &[u8] {
+@@ -268,7 +272,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1014,15 +942,7 @@ index b286e40..7472d9c 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -279,6 +287,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -307,7 +316,7 @@ impl Write for &mut [u8] {
+@@ -307,7 +310,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1031,14 +951,6 @@ index b286e40..7472d9c 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -315,6 +324,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index 4c88fc8..2059b5a 100644
 --- a/mod.rs
@@ -1072,9 +984,9 @@ index 4c88fc8..2059b5a 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1134,23 +1046,7 @@ index 4c88fc8..2059b5a 100644
  fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
                                                    buf: &mut Vec<u8>,
                                                    reservation_size: usize) -> Result<usize>
-@@ -390,6 +381,7 @@ fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
-     ret
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_read_vectored<F>(read: F, bufs: &mut [IoVecMut<'_>]) -> Result<usize>
- where
-     F: FnOnce(&mut [u8]) -> Result<usize>
-@@ -401,6 +393,7 @@ where
-     read(buf)
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_write_vectored<F>(write: F, bufs: &[IoVec<'_>]) -> Result<usize>
- where
-     F: FnOnce(&[u8]) -> Result<usize>
-@@ -484,7 +477,6 @@ where
+@@ -484,7 +475,6 @@ where
  /// [`BufReader`]: struct.BufReader.html
  /// [`&str`]: ../../std/primitive.str.html
  /// [slice]: ../../std/primitive.slice.html
@@ -1158,7 +1054,7 @@ index 4c88fc8..2059b5a 100644
  #[doc(spotlight)]
  pub trait Read {
      /// Pull some bytes from this source into the specified buffer, returning
-@@ -541,7 +533,6 @@ pub trait Read {
+@@ -541,7 +531,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1166,16 +1062,15 @@ index 4c88fc8..2059b5a 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -552,7 +543,7 @@ pub trait Read {
+@@ -552,7 +541,6 @@ pub trait Read {
      ///
      /// The default implementation calls `read` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          default_read_vectored(|b| self.read(b), bufs)
      }
-@@ -579,7 +570,6 @@ pub trait Read {
+@@ -579,7 +567,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1183,7 +1078,7 @@ index 4c88fc8..2059b5a 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -632,7 +622,7 @@ pub trait Read {
+@@ -632,7 +619,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1192,7 +1087,7 @@ index 4c88fc8..2059b5a 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -675,7 +665,7 @@ pub trait Read {
+@@ -675,7 +662,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1201,7 +1096,7 @@ index 4c88fc8..2059b5a 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -738,7 +728,6 @@ pub trait Read {
+@@ -738,7 +725,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1104,7 @@ index 4c88fc8..2059b5a 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -790,7 +779,6 @@ pub trait Read {
+@@ -790,7 +776,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1217,7 +1112,7 @@ index 4c88fc8..2059b5a 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -827,7 +815,6 @@ pub trait Read {
+@@ -827,7 +812,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1225,7 +1120,7 @@ index 4c88fc8..2059b5a 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -862,7 +849,6 @@ pub trait Read {
+@@ -862,7 +846,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1233,7 +1128,7 @@ index 4c88fc8..2059b5a 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -898,42 +884,77 @@ pub trait Read {
+@@ -898,22 +881,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1243,10 +1138,8 @@ index 4c88fc8..2059b5a 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1258,10 +1151,9 @@ index 4c88fc8..2059b5a 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1285,23 +1177,15 @@ index 4c88fc8..2059b5a 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -926,14 +939,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1314,41 +1198,31 @@ index 4c88fc8..2059b5a 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -943,7 +964,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -943,7 +954,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -956,31 +977,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -956,11 +966,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -973,14 +981,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1361,11 +1235,10 @@ index 4c88fc8..2059b5a 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -991,13 +1012,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -991,13 +997,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1379,7 +1252,7 @@ index 4c88fc8..2059b5a 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -1011,21 +1030,18 @@ impl Initializer {
+@@ -1011,21 +1015,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1401,7 +1274,7 @@ index 4c88fc8..2059b5a 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1068,7 +1084,6 @@ impl Initializer {
+@@ -1068,7 +1069,6 @@ impl Initializer {
  ///     Ok(())
  /// }
  /// ```
@@ -1409,7 +1282,7 @@ index 4c88fc8..2059b5a 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1117,7 +1132,6 @@ pub trait Write {
+@@ -1117,7 +1117,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1417,16 +1290,15 @@ index 4c88fc8..2059b5a 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1128,7 +1142,7 @@ pub trait Write {
+@@ -1128,7 +1127,6 @@ pub trait Write {
      ///
      /// The default implementation calls `write` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          default_write_vectored(|b| self.write(b), bufs)
      }
-@@ -1156,7 +1170,6 @@ pub trait Write {
+@@ -1156,7 +1154,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1306,7 @@ index 4c88fc8..2059b5a 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1189,7 +1202,6 @@ pub trait Write {
+@@ -1189,7 +1186,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1442,7 +1314,7 @@ index 4c88fc8..2059b5a 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1241,7 +1253,6 @@ pub trait Write {
+@@ -1241,7 +1237,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1450,7 +1322,7 @@ index 4c88fc8..2059b5a 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1297,7 +1308,6 @@ pub trait Write {
+@@ -1297,7 +1292,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1458,7 +1330,7 @@ index 4c88fc8..2059b5a 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1327,7 +1337,6 @@ pub trait Write {
+@@ -1327,7 +1321,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1466,7 +1338,7 @@ index 4c88fc8..2059b5a 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1343,7 +1352,6 @@ pub trait Seek {
+@@ -1343,7 +1336,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1474,7 +1346,7 @@ index 4c88fc8..2059b5a 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  
      /// Returns the length of this stream (in bytes).
-@@ -1381,7 +1389,6 @@ pub trait Seek {
+@@ -1381,7 +1373,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1482,7 +1354,7 @@ index 4c88fc8..2059b5a 100644
      fn stream_len(&mut self) -> Result<u64> {
          let old_pos = self.stream_position()?;
          let len = self.seek(SeekFrom::End(0))?;
-@@ -1420,7 +1427,6 @@ pub trait Seek {
+@@ -1420,7 +1411,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1490,7 +1362,7 @@ index 4c88fc8..2059b5a 100644
      fn stream_position(&mut self) -> Result<u64> {
          self.seek(SeekFrom::Current(0))
      }
-@@ -1432,29 +1438,26 @@ pub trait Seek {
+@@ -1432,29 +1422,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1524,7 +1396,7 @@ index 4c88fc8..2059b5a 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1534,7 +1537,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1534,7 +1521,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1533,7 +1405,7 @@ index 4c88fc8..2059b5a 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1580,7 +1583,6 @@ pub trait BufRead: Read {
+@@ -1580,7 +1567,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1541,7 +1413,7 @@ index 4c88fc8..2059b5a 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1602,7 +1604,6 @@ pub trait BufRead: Read {
+@@ -1602,7 +1588,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1549,7 +1421,7 @@ index 4c88fc8..2059b5a 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1658,7 +1659,6 @@ pub trait BufRead: Read {
+@@ -1658,7 +1643,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1557,7 +1429,7 @@ index 4c88fc8..2059b5a 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1717,7 +1717,6 @@ pub trait BufRead: Read {
+@@ -1717,7 +1701,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1565,7 +1437,7 @@ index 4c88fc8..2059b5a 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1758,7 +1757,6 @@ pub trait BufRead: Read {
+@@ -1758,7 +1741,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1573,7 +1445,7 @@ index 4c88fc8..2059b5a 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1797,7 +1795,6 @@ pub trait BufRead: Read {
+@@ -1797,7 +1779,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1581,7 +1453,7 @@ index 4c88fc8..2059b5a 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1809,7 +1806,6 @@ pub trait BufRead: Read {
+@@ -1809,7 +1790,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1589,7 +1461,7 @@ index 4c88fc8..2059b5a 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1835,7 +1831,6 @@ impl<T, U> Chain<T, U> {
+@@ -1835,7 +1815,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1597,7 +1469,7 @@ index 4c88fc8..2059b5a 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1858,7 +1853,6 @@ impl<T, U> Chain<T, U> {
+@@ -1858,7 +1837,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1605,7 +1477,7 @@ index 4c88fc8..2059b5a 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1885,13 +1879,11 @@ impl<T, U> Chain<T, U> {
+@@ -1885,13 +1863,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1619,7 +1491,7 @@ index 4c88fc8..2059b5a 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1901,7 +1893,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1901,7 +1877,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1627,15 +1499,7 @@ index 4c88fc8..2059b5a 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1913,6 +1904,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1933,7 +1925,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1933,7 +1908,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1644,7 +1508,7 @@ index 4c88fc8..2059b5a 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1960,7 +1952,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1960,7 +1935,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1652,7 +1516,7 @@ index 4c88fc8..2059b5a 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -1995,7 +1986,6 @@ impl<T> Take<T> {
+@@ -1995,7 +1969,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1660,7 +1524,7 @@ index 4c88fc8..2059b5a 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -2021,7 +2011,6 @@ impl<T> Take<T> {
+@@ -2021,7 +1994,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1668,7 +1532,7 @@ index 4c88fc8..2059b5a 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -2046,7 +2035,6 @@ impl<T> Take<T> {
+@@ -2046,7 +2018,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1676,7 +1540,7 @@ index 4c88fc8..2059b5a 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -2071,7 +2059,6 @@ impl<T> Take<T> {
+@@ -2071,7 +2042,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1684,7 +1548,7 @@ index 4c88fc8..2059b5a 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2100,13 +2087,11 @@ impl<T> Take<T> {
+@@ -2100,13 +2070,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1698,16 +1562,16 @@ index 4c88fc8..2059b5a 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2123,15 +2108,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2124,6 +2092,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2131,7 +2100,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1715,7 +1579,7 @@ index 4c88fc8..2059b5a 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2158,13 +2137,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2158,13 +2127,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1729,7 +1593,7 @@ index 4c88fc8..2059b5a 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2188,14 +2165,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2188,14 +2155,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1746,7 +1610,7 @@ index 4c88fc8..2059b5a 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2220,13 +2197,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2220,13 +2187,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1789,8 +1653,8 @@ index 6aaf8f1..447ce47 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1859,15 +1723,7 @@ index 6aaf8f1..447ce47 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1875,7 +1731,7 @@ index 6aaf8f1..447ce47 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1883,7 +1739,7 @@ index 6aaf8f1..447ce47 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1894,12 +1750,7 @@ index 6aaf8f1..447ce47 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/8dbae794b0683668d1b46d2c319ab36dcd9bd96d.patch
+++ b/patches/8dbae794b0683668d1b46d2c319ab36dcd9bd96d.patch
@@ -15,7 +15,7 @@ index 441f6b9..540d4aa 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -311,21 +311,19 @@ diff --git a/cursor.rs b/cursor.rs
 index 247d45c..f13522d 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 247d45c..f13522d 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 247d45c..f13522d 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 247d45c..f13522d 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 247d45c..f13522d 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 247d45c..f13522d 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 247d45c..f13522d 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 247d45c..f13522d 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -222,14 +215,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -222,10 +214,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -244,7 +237,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -244,7 +235,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -255,12 +248,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -255,12 +246,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 247d45c..f13522d 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -272,6 +269,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -290,6 +288,7 @@ fn slice_write_vectored(
+@@ -290,6 +285,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 247d45c..f13522d 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -316,6 +315,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -316,6 +312,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 247d45c..f13522d 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -329,13 +329,13 @@ fn vec_write_vectored(
+@@ -329,7 +326,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -344,12 +344,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -344,7 +340,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -357,12 +358,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -357,7 +353,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -370,13 +372,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -370,8 +366,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 247d45c..f13522d 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index 614b791..e4ce8b5 100644
 --- a/error.rs
@@ -844,7 +804,7 @@ diff --git a/impls.rs b/impls.rs
 index b286e40..7472d9c 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -852,8 +812,8 @@ index b286e40..7472d9c 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -866,14 +826,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -887,7 +840,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -895,12 +848,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -914,7 +862,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -923,14 +871,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -944,7 +885,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -953,12 +894,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -973,7 +909,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -186,7 +194,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
+@@ -186,7 +190,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -981,15 +917,7 @@ index b286e40..7472d9c 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -206,6 +213,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -245,6 +253,7 @@ impl Read for &[u8] {
+@@ -245,6 +248,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -997,7 +925,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -254,7 +263,7 @@ impl Read for &[u8] {
+@@ -254,7 +258,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -1006,7 +934,7 @@ index b286e40..7472d9c 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -268,7 +277,6 @@ impl BufRead for &[u8] {
+@@ -268,7 +272,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1014,15 +942,7 @@ index b286e40..7472d9c 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -279,6 +287,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -307,7 +316,7 @@ impl Write for &mut [u8] {
+@@ -307,7 +310,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1031,14 +951,6 @@ index b286e40..7472d9c 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -315,6 +324,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index 14c850b..eaa3481 100644
 --- a/mod.rs
@@ -1072,9 +984,9 @@ index 14c850b..eaa3481 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1134,23 +1046,7 @@ index 14c850b..eaa3481 100644
  fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
                                                    buf: &mut Vec<u8>,
                                                    reservation_size: usize) -> Result<usize>
-@@ -390,6 +381,7 @@ fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
-     ret
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_read_vectored<F>(read: F, bufs: &mut [IoVecMut<'_>]) -> Result<usize>
- where
-     F: FnOnce(&mut [u8]) -> Result<usize>
-@@ -401,6 +393,7 @@ where
-     read(buf)
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_write_vectored<F>(write: F, bufs: &[IoVec<'_>]) -> Result<usize>
- where
-     F: FnOnce(&[u8]) -> Result<usize>
-@@ -484,7 +477,6 @@ where
+@@ -484,7 +475,6 @@ where
  /// [`BufReader`]: struct.BufReader.html
  /// [`&str`]: ../../std/primitive.str.html
  /// [slice]: ../../std/primitive.slice.html
@@ -1158,7 +1054,7 @@ index 14c850b..eaa3481 100644
  #[doc(spotlight)]
  pub trait Read {
      /// Pull some bytes from this source into the specified buffer, returning
-@@ -541,7 +533,6 @@ pub trait Read {
+@@ -541,7 +531,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1166,16 +1062,15 @@ index 14c850b..eaa3481 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -552,7 +543,7 @@ pub trait Read {
+@@ -552,7 +541,6 @@ pub trait Read {
      ///
      /// The default implementation calls `read` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          default_read_vectored(|b| self.read(b), bufs)
      }
-@@ -579,7 +570,6 @@ pub trait Read {
+@@ -579,7 +567,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1183,7 +1078,7 @@ index 14c850b..eaa3481 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -632,7 +622,7 @@ pub trait Read {
+@@ -632,7 +619,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1192,7 +1087,7 @@ index 14c850b..eaa3481 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -675,7 +665,7 @@ pub trait Read {
+@@ -675,7 +662,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1201,7 +1096,7 @@ index 14c850b..eaa3481 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -738,7 +728,6 @@ pub trait Read {
+@@ -738,7 +725,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1104,7 @@ index 14c850b..eaa3481 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -790,7 +779,6 @@ pub trait Read {
+@@ -790,7 +776,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1217,7 +1112,7 @@ index 14c850b..eaa3481 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -827,7 +815,6 @@ pub trait Read {
+@@ -827,7 +812,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1225,7 +1120,7 @@ index 14c850b..eaa3481 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -862,7 +849,6 @@ pub trait Read {
+@@ -862,7 +846,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1233,7 +1128,7 @@ index 14c850b..eaa3481 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -898,42 +884,77 @@ pub trait Read {
+@@ -898,22 +881,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1243,10 +1138,8 @@ index 14c850b..eaa3481 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1258,10 +1151,9 @@ index 14c850b..eaa3481 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1285,23 +1177,15 @@ index 14c850b..eaa3481 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -926,14 +939,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1314,41 +1198,31 @@ index 14c850b..eaa3481 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -943,7 +964,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -943,7 +954,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -956,31 +977,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -956,11 +966,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -973,14 +981,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1361,11 +1235,10 @@ index 14c850b..eaa3481 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -991,13 +1012,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -991,13 +997,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1379,7 +1252,7 @@ index 14c850b..eaa3481 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -1011,21 +1030,18 @@ impl Initializer {
+@@ -1011,21 +1015,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1401,7 +1274,7 @@ index 14c850b..eaa3481 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1068,7 +1084,6 @@ impl Initializer {
+@@ -1068,7 +1069,6 @@ impl Initializer {
  ///     Ok(())
  /// }
  /// ```
@@ -1409,7 +1282,7 @@ index 14c850b..eaa3481 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1117,7 +1132,6 @@ pub trait Write {
+@@ -1117,7 +1117,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1417,16 +1290,15 @@ index 14c850b..eaa3481 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1128,7 +1142,7 @@ pub trait Write {
+@@ -1128,7 +1127,6 @@ pub trait Write {
      ///
      /// The default implementation calls `write` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          default_write_vectored(|b| self.write(b), bufs)
      }
-@@ -1156,7 +1170,6 @@ pub trait Write {
+@@ -1156,7 +1154,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1306,7 @@ index 14c850b..eaa3481 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1189,7 +1202,6 @@ pub trait Write {
+@@ -1189,7 +1186,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1442,7 +1314,7 @@ index 14c850b..eaa3481 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1241,7 +1253,6 @@ pub trait Write {
+@@ -1241,7 +1237,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1450,7 +1322,7 @@ index 14c850b..eaa3481 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1297,7 +1308,6 @@ pub trait Write {
+@@ -1297,7 +1292,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1458,7 +1330,7 @@ index 14c850b..eaa3481 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1327,7 +1337,6 @@ pub trait Write {
+@@ -1327,7 +1321,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1466,7 +1338,7 @@ index 14c850b..eaa3481 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1343,7 +1352,6 @@ pub trait Seek {
+@@ -1343,7 +1336,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1474,7 +1346,7 @@ index 14c850b..eaa3481 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  
      /// Returns the length of this stream (in bytes).
-@@ -1381,7 +1389,6 @@ pub trait Seek {
+@@ -1381,7 +1373,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1482,7 +1354,7 @@ index 14c850b..eaa3481 100644
      fn stream_len(&mut self) -> Result<u64> {
          let old_pos = self.stream_position()?;
          let len = self.seek(SeekFrom::End(0))?;
-@@ -1420,7 +1427,6 @@ pub trait Seek {
+@@ -1420,7 +1411,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1490,7 +1362,7 @@ index 14c850b..eaa3481 100644
      fn stream_position(&mut self) -> Result<u64> {
          self.seek(SeekFrom::Current(0))
      }
-@@ -1432,29 +1438,26 @@ pub trait Seek {
+@@ -1432,29 +1422,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1524,7 +1396,7 @@ index 14c850b..eaa3481 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1534,7 +1537,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1534,7 +1521,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1533,7 +1405,7 @@ index 14c850b..eaa3481 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1580,7 +1583,6 @@ pub trait BufRead: Read {
+@@ -1580,7 +1567,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1541,7 +1413,7 @@ index 14c850b..eaa3481 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1602,7 +1604,6 @@ pub trait BufRead: Read {
+@@ -1602,7 +1588,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1549,7 +1421,7 @@ index 14c850b..eaa3481 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1658,7 +1659,6 @@ pub trait BufRead: Read {
+@@ -1658,7 +1643,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1557,7 +1429,7 @@ index 14c850b..eaa3481 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1717,7 +1717,6 @@ pub trait BufRead: Read {
+@@ -1717,7 +1701,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1565,7 +1437,7 @@ index 14c850b..eaa3481 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1758,7 +1757,6 @@ pub trait BufRead: Read {
+@@ -1758,7 +1741,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1573,7 +1445,7 @@ index 14c850b..eaa3481 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1797,7 +1795,6 @@ pub trait BufRead: Read {
+@@ -1797,7 +1779,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1581,7 +1453,7 @@ index 14c850b..eaa3481 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1809,7 +1806,6 @@ pub trait BufRead: Read {
+@@ -1809,7 +1790,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1589,7 +1461,7 @@ index 14c850b..eaa3481 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1835,7 +1831,6 @@ impl<T, U> Chain<T, U> {
+@@ -1835,7 +1815,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1597,7 +1469,7 @@ index 14c850b..eaa3481 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1858,7 +1853,6 @@ impl<T, U> Chain<T, U> {
+@@ -1858,7 +1837,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1605,7 +1477,7 @@ index 14c850b..eaa3481 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1885,13 +1879,11 @@ impl<T, U> Chain<T, U> {
+@@ -1885,13 +1863,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1619,7 +1491,7 @@ index 14c850b..eaa3481 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1901,7 +1893,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1901,7 +1877,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1627,15 +1499,7 @@ index 14c850b..eaa3481 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1913,6 +1904,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1933,7 +1925,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1933,7 +1908,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1644,7 +1508,7 @@ index 14c850b..eaa3481 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1960,7 +1952,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1960,7 +1935,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1652,7 +1516,7 @@ index 14c850b..eaa3481 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -1995,7 +1986,6 @@ impl<T> Take<T> {
+@@ -1995,7 +1969,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1660,7 +1524,7 @@ index 14c850b..eaa3481 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -2021,7 +2011,6 @@ impl<T> Take<T> {
+@@ -2021,7 +1994,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1668,7 +1532,7 @@ index 14c850b..eaa3481 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -2046,7 +2035,6 @@ impl<T> Take<T> {
+@@ -2046,7 +2018,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1676,7 +1540,7 @@ index 14c850b..eaa3481 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -2071,7 +2059,6 @@ impl<T> Take<T> {
+@@ -2071,7 +2042,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1684,7 +1548,7 @@ index 14c850b..eaa3481 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2100,13 +2087,11 @@ impl<T> Take<T> {
+@@ -2100,13 +2070,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1698,16 +1562,16 @@ index 14c850b..eaa3481 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2123,15 +2108,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2124,6 +2092,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2131,7 +2100,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1715,7 +1579,7 @@ index 14c850b..eaa3481 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2158,13 +2137,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2158,13 +2127,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1729,7 +1593,7 @@ index 14c850b..eaa3481 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2188,14 +2165,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2188,14 +2155,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1746,7 +1610,7 @@ index 14c850b..eaa3481 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2220,13 +2197,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2220,13 +2187,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1789,8 +1653,8 @@ index 6aaf8f1..447ce47 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1859,15 +1723,7 @@ index 6aaf8f1..447ce47 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1875,7 +1731,7 @@ index 6aaf8f1..447ce47 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1883,7 +1739,7 @@ index 6aaf8f1..447ce47 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1894,12 +1750,7 @@ index 6aaf8f1..447ce47 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/93b6d9e086c6910118a57e4332c9448ab550931f.patch
+++ b/patches/93b6d9e086c6910118a57e4332c9448ab550931f.patch
@@ -15,7 +15,7 @@ index 559a54d..bd888d2 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -311,21 +311,19 @@ diff --git a/cursor.rs b/cursor.rs
 index 873da08..3d39e57 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 873da08..3d39e57 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 873da08..3d39e57 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 873da08..3d39e57 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 873da08..3d39e57 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 873da08..3d39e57 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 873da08..3d39e57 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 873da08..3d39e57 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -214,14 +207,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -214,10 +206,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 873da08..3d39e57 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -236,7 +229,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -236,7 +227,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 873da08..3d39e57 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -247,12 +240,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -247,12 +238,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 873da08..3d39e57 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -264,6 +261,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -282,6 +280,7 @@ fn slice_write_vectored(
+@@ -282,6 +277,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 873da08..3d39e57 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -308,6 +307,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -308,6 +304,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 873da08..3d39e57 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -321,13 +321,13 @@ fn vec_write_vectored(
+@@ -321,7 +318,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -336,12 +336,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -336,7 +332,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -349,12 +350,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -349,7 +345,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -362,13 +364,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -362,8 +358,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 873da08..3d39e57 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index fdc5625..e4ce8b5 100644
 --- a/error.rs
@@ -836,7 +796,7 @@ diff --git a/impls.rs b/impls.rs
 index bd3d0a4..c44cc70 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -844,8 +804,8 @@ index bd3d0a4..c44cc70 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -858,14 +818,7 @@ index bd3d0a4..c44cc70 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -879,7 +832,7 @@ index bd3d0a4..c44cc70 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -887,12 +840,7 @@ index bd3d0a4..c44cc70 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -906,7 +854,7 @@ index bd3d0a4..c44cc70 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -915,14 +863,7 @@ index bd3d0a4..c44cc70 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -936,7 +877,7 @@ index bd3d0a4..c44cc70 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -945,12 +886,7 @@ index bd3d0a4..c44cc70 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -965,7 +901,7 @@ index bd3d0a4..c44cc70 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -172,7 +180,6 @@ impl<B: BufRead + ?Sized> BufRead for Box<B> {
+@@ -172,7 +176,6 @@ impl<B: BufRead + ?Sized> BufRead for Box<B> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -973,15 +909,7 @@ index bd3d0a4..c44cc70 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -192,6 +199,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -231,6 +239,7 @@ impl Read for &[u8] {
+@@ -231,6 +234,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -989,7 +917,7 @@ index bd3d0a4..c44cc70 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -240,7 +249,7 @@ impl Read for &[u8] {
+@@ -240,7 +244,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -998,7 +926,7 @@ index bd3d0a4..c44cc70 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -254,7 +263,6 @@ impl BufRead for &[u8] {
+@@ -254,7 +258,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1006,15 +934,7 @@ index bd3d0a4..c44cc70 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -265,6 +273,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -293,7 +302,7 @@ impl Write for &mut [u8] {
+@@ -293,7 +296,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1023,14 +943,6 @@ index bd3d0a4..c44cc70 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -301,6 +310,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index e3e2754..400eca6 100644
 --- a/mod.rs
@@ -1064,9 +976,9 @@ index e3e2754..400eca6 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1142,16 +1054,15 @@ index e3e2754..400eca6 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -530,7 +519,7 @@ pub trait Read {
+@@ -530,7 +519,6 @@ pub trait Read {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `read`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          match bufs.iter_mut().find(|b| !b.is_empty()) {
              Some(buf) => self.read(buf),
-@@ -560,7 +549,6 @@ pub trait Read {
+@@ -560,7 +548,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1159,7 +1070,7 @@ index e3e2754..400eca6 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -613,7 +601,7 @@ pub trait Read {
+@@ -613,7 +600,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1168,7 +1079,7 @@ index e3e2754..400eca6 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -656,7 +644,7 @@ pub trait Read {
+@@ -656,7 +643,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1177,7 +1088,7 @@ index e3e2754..400eca6 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -719,7 +707,6 @@ pub trait Read {
+@@ -719,7 +706,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1185,7 +1096,7 @@ index e3e2754..400eca6 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -771,7 +758,6 @@ pub trait Read {
+@@ -771,7 +757,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1193,7 +1104,7 @@ index e3e2754..400eca6 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -808,7 +794,6 @@ pub trait Read {
+@@ -808,7 +793,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1201,7 +1112,7 @@ index e3e2754..400eca6 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -843,7 +828,6 @@ pub trait Read {
+@@ -843,7 +827,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1120,7 @@ index e3e2754..400eca6 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -879,42 +863,77 @@ pub trait Read {
+@@ -879,22 +862,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1219,10 +1130,8 @@ index e3e2754..400eca6 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1234,10 +1143,9 @@ index e3e2754..400eca6 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1261,23 +1169,15 @@ index e3e2754..400eca6 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -907,14 +920,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1290,41 +1190,31 @@ index e3e2754..400eca6 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -924,7 +943,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -924,7 +935,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -937,31 +956,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -937,11 +947,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -954,14 +962,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1337,11 +1227,10 @@ index e3e2754..400eca6 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -972,13 +991,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -972,13 +978,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1355,7 +1244,7 @@ index e3e2754..400eca6 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -992,21 +1009,18 @@ impl Initializer {
+@@ -992,21 +996,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1377,7 +1266,7 @@ index e3e2754..400eca6 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1049,7 +1063,6 @@ impl Initializer {
+@@ -1049,7 +1050,6 @@ impl Initializer {
  ///     Ok(())
  /// }
  /// ```
@@ -1385,7 +1274,7 @@ index e3e2754..400eca6 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1098,7 +1111,6 @@ pub trait Write {
+@@ -1098,7 +1098,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1393,16 +1282,15 @@ index e3e2754..400eca6 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1109,7 +1121,7 @@ pub trait Write {
+@@ -1109,7 +1108,6 @@ pub trait Write {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `write`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          match bufs.iter().find(|b| !b.is_empty()) {
              Some(buf) => self.write(buf),
-@@ -1140,7 +1152,6 @@ pub trait Write {
+@@ -1140,7 +1138,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1410,7 +1298,7 @@ index e3e2754..400eca6 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1173,7 +1184,6 @@ pub trait Write {
+@@ -1173,7 +1170,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1418,7 +1306,7 @@ index e3e2754..400eca6 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1225,7 +1235,6 @@ pub trait Write {
+@@ -1225,7 +1221,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1426,7 +1314,7 @@ index e3e2754..400eca6 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1281,7 +1290,6 @@ pub trait Write {
+@@ -1281,7 +1276,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1322,7 @@ index e3e2754..400eca6 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1311,7 +1319,6 @@ pub trait Write {
+@@ -1311,7 +1305,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1442,7 +1330,7 @@ index e3e2754..400eca6 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1327,7 +1334,6 @@ pub trait Seek {
+@@ -1327,7 +1320,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1450,7 +1338,7 @@ index e3e2754..400eca6 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  }
  
-@@ -1337,29 +1343,26 @@ pub trait Seek {
+@@ -1337,29 +1329,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1484,7 +1372,7 @@ index e3e2754..400eca6 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1439,7 +1442,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1439,7 +1428,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1493,7 +1381,7 @@ index e3e2754..400eca6 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1485,7 +1488,6 @@ pub trait BufRead: Read {
+@@ -1485,7 +1474,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1501,7 +1389,7 @@ index e3e2754..400eca6 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1507,7 +1509,6 @@ pub trait BufRead: Read {
+@@ -1507,7 +1495,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1509,7 +1397,7 @@ index e3e2754..400eca6 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1563,7 +1564,6 @@ pub trait BufRead: Read {
+@@ -1563,7 +1550,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1517,7 +1405,7 @@ index e3e2754..400eca6 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1622,7 +1622,6 @@ pub trait BufRead: Read {
+@@ -1622,7 +1608,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1525,7 +1413,7 @@ index e3e2754..400eca6 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1663,7 +1662,6 @@ pub trait BufRead: Read {
+@@ -1663,7 +1648,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1533,7 +1421,7 @@ index e3e2754..400eca6 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1702,7 +1700,6 @@ pub trait BufRead: Read {
+@@ -1702,7 +1686,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1541,7 +1429,7 @@ index e3e2754..400eca6 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1714,7 +1711,6 @@ pub trait BufRead: Read {
+@@ -1714,7 +1697,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1549,7 +1437,7 @@ index e3e2754..400eca6 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1740,7 +1736,6 @@ impl<T, U> Chain<T, U> {
+@@ -1740,7 +1722,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1557,7 +1445,7 @@ index e3e2754..400eca6 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1763,7 +1758,6 @@ impl<T, U> Chain<T, U> {
+@@ -1763,7 +1744,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1565,7 +1453,7 @@ index e3e2754..400eca6 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1790,13 +1784,11 @@ impl<T, U> Chain<T, U> {
+@@ -1790,13 +1770,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1579,7 +1467,7 @@ index e3e2754..400eca6 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1806,7 +1798,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1806,7 +1784,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1587,15 +1475,7 @@ index e3e2754..400eca6 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1818,6 +1809,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1838,7 +1830,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1838,7 +1815,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1604,7 +1484,7 @@ index e3e2754..400eca6 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1865,7 +1857,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1865,7 +1842,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1612,7 +1492,7 @@ index e3e2754..400eca6 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -1900,7 +1891,6 @@ impl<T> Take<T> {
+@@ -1900,7 +1876,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1620,7 +1500,7 @@ index e3e2754..400eca6 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -1926,7 +1916,6 @@ impl<T> Take<T> {
+@@ -1926,7 +1901,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1628,7 +1508,7 @@ index e3e2754..400eca6 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -1951,7 +1940,6 @@ impl<T> Take<T> {
+@@ -1951,7 +1925,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1636,7 +1516,7 @@ index e3e2754..400eca6 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -1976,7 +1964,6 @@ impl<T> Take<T> {
+@@ -1976,7 +1949,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1644,7 +1524,7 @@ index e3e2754..400eca6 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2005,13 +1992,11 @@ impl<T> Take<T> {
+@@ -2005,13 +1977,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1658,16 +1538,16 @@ index e3e2754..400eca6 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2028,15 +2013,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2029,6 +1999,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2036,7 +2007,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1675,7 +1555,7 @@ index e3e2754..400eca6 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2063,13 +2042,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2063,13 +2034,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1689,7 +1569,7 @@ index e3e2754..400eca6 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2093,14 +2070,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2093,14 +2062,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1706,7 +1586,7 @@ index e3e2754..400eca6 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2125,13 +2102,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2125,13 +2094,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1739,7 +1619,7 @@ index 2e19edf..66294a3 100644
 +#[cfg(feature="collections")] pub use alloc::boxed::Box;
 +#[cfg(feature="collections")] pub use collections::vec::Vec;
 diff --git a/util.rs b/util.rs
-index 6aaf8f1..447ce47 100644
+index 6aaf8f1..15ce0af 100644
 --- a/util.rs
 +++ b/util.rs
 @@ -1,8 +1,9 @@
@@ -1749,8 +1629,8 @@ index 6aaf8f1..447ce47 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1819,15 +1699,7 @@ index 6aaf8f1..447ce47 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1835,7 +1707,7 @@ index 6aaf8f1..447ce47 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1843,7 +1715,7 @@ index 6aaf8f1..447ce47 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1854,12 +1726,7 @@ index 6aaf8f1..447ce47 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/99ed06eb8864e704c4a1871ccda4648273bee4ef.patch
+++ b/patches/99ed06eb8864e704c4a1871ccda4648273bee4ef.patch
@@ -962,8 +962,8 @@ index c0570ae..f10d775 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+use core::ptr;
 +use core::slice;
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1404,16 +1404,16 @@ index c0570ae..f10d775 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1898,15 +1847,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1899,6 +1848,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1906,7 +1856,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1421,7 +1421,7 @@ index c0570ae..f10d775 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1933,13 +1876,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -1933,13 +1883,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1435,7 +1435,7 @@ index c0570ae..f10d775 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1963,14 +1904,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1963,14 +1911,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1452,7 +1452,7 @@ index c0570ae..f10d775 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -1995,13 +1936,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -1995,13 +1943,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1496,8 +1496,8 @@ index 8df961a..2b08122 100644
 -use mem;
 +use core::fmt;
 +use io::{self, Read, Initializer, Write, ErrorKind};
-+use core::mem;
 +#[cfg(feature="collections")] use io::BufRead;
++use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
  ///

--- a/patches/b20bba4f3777fd097539e1f516987e0d9729d710.patch
+++ b/patches/b20bba4f3777fd097539e1f516987e0d9729d710.patch
@@ -1409,16 +1409,16 @@ index e263db2..2176464 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1907,15 +1856,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1908,6 +1857,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1915,7 +1865,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1426,7 +1426,7 @@ index e263db2..2176464 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1954,13 +1897,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1954,13 +1904,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1440,7 +1440,7 @@ index e263db2..2176464 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1976,14 +1917,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1976,14 +1924,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1457,7 +1457,7 @@ index e263db2..2176464 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2008,13 +1949,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2008,13 +1956,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/b5ed39ff10f0e46be6e97b577477e0f60234fa0b.patch
+++ b/patches/b5ed39ff10f0e46be6e97b577477e0f60234fa0b.patch
@@ -1408,16 +1408,16 @@ index b83f3fb..883fa30 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1906,15 +1855,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1907,6 +1856,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1914,7 +1864,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1425,7 +1425,7 @@ index b83f3fb..883fa30 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1953,13 +1896,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1953,13 +1903,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1439,7 +1439,7 @@ index b83f3fb..883fa30 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1975,14 +1916,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1975,14 +1923,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1456,7 +1456,7 @@ index b83f3fb..883fa30 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2007,13 +1948,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2007,13 +1955,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/b6fb3e34117008f7f97094b0f1521116a4e66473.patch
+++ b/patches/b6fb3e34117008f7f97094b0f1521116a4e66473.patch
@@ -15,7 +15,7 @@ index 441f6b9..540d4aa 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -311,21 +311,19 @@ diff --git a/cursor.rs b/cursor.rs
 index 247d45c..f13522d 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 247d45c..f13522d 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 247d45c..f13522d 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 247d45c..f13522d 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 247d45c..f13522d 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 247d45c..f13522d 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 247d45c..f13522d 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 247d45c..f13522d 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -222,14 +215,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -222,10 +214,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -244,7 +237,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -244,7 +235,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -255,12 +248,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -255,12 +246,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 247d45c..f13522d 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -272,6 +269,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -290,6 +288,7 @@ fn slice_write_vectored(
+@@ -290,6 +285,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 247d45c..f13522d 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -316,6 +315,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -316,6 +312,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 247d45c..f13522d 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -329,13 +329,13 @@ fn vec_write_vectored(
+@@ -329,7 +326,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -344,12 +344,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -344,7 +340,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -357,12 +358,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -357,7 +353,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -370,13 +372,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -370,8 +366,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 247d45c..f13522d 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index 614b791..e4ce8b5 100644
 --- a/error.rs
@@ -844,7 +804,7 @@ diff --git a/impls.rs b/impls.rs
 index b286e40..7472d9c 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -852,8 +812,8 @@ index b286e40..7472d9c 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -866,14 +826,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -887,7 +840,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -895,12 +848,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -914,7 +862,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -923,14 +871,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -944,7 +885,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -953,12 +894,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -973,7 +909,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -186,7 +194,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
+@@ -186,7 +190,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -981,15 +917,7 @@ index b286e40..7472d9c 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -206,6 +213,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -245,6 +253,7 @@ impl Read for &[u8] {
+@@ -245,6 +248,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -997,7 +925,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -254,7 +263,7 @@ impl Read for &[u8] {
+@@ -254,7 +258,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -1006,7 +934,7 @@ index b286e40..7472d9c 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -268,7 +277,6 @@ impl BufRead for &[u8] {
+@@ -268,7 +272,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1014,15 +942,7 @@ index b286e40..7472d9c 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -279,6 +287,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -307,7 +316,7 @@ impl Write for &mut [u8] {
+@@ -307,7 +310,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1031,14 +951,6 @@ index b286e40..7472d9c 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -315,6 +324,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index 14a16f3..07792b7 100644
 --- a/mod.rs
@@ -1072,9 +984,9 @@ index 14a16f3..07792b7 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1134,23 +1046,7 @@ index 14a16f3..07792b7 100644
  fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
                                                    buf: &mut Vec<u8>,
                                                    reservation_size: usize) -> Result<usize>
-@@ -390,6 +381,7 @@ fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
-     ret
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_read_vectored<F>(read: F, bufs: &mut [IoVecMut<'_>]) -> Result<usize>
- where
-     F: FnOnce(&mut [u8]) -> Result<usize>
-@@ -401,6 +393,7 @@ where
-     read(buf)
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_write_vectored<F>(write: F, bufs: &[IoVec<'_>]) -> Result<usize>
- where
-     F: FnOnce(&[u8]) -> Result<usize>
-@@ -484,7 +477,6 @@ where
+@@ -484,7 +475,6 @@ where
  /// [`BufReader`]: struct.BufReader.html
  /// [`&str`]: ../../std/primitive.str.html
  /// [slice]: ../../std/primitive.slice.html
@@ -1158,7 +1054,7 @@ index 14a16f3..07792b7 100644
  #[doc(spotlight)]
  pub trait Read {
      /// Pull some bytes from this source into the specified buffer, returning
-@@ -543,7 +535,6 @@ pub trait Read {
+@@ -543,7 +533,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1166,16 +1062,15 @@ index 14a16f3..07792b7 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -554,7 +545,7 @@ pub trait Read {
+@@ -554,7 +543,6 @@ pub trait Read {
      ///
      /// The default implementation calls `read` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          default_read_vectored(|b| self.read(b), bufs)
      }
-@@ -581,7 +572,6 @@ pub trait Read {
+@@ -581,7 +569,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1183,7 +1078,7 @@ index 14a16f3..07792b7 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -634,7 +624,7 @@ pub trait Read {
+@@ -634,7 +621,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1192,7 +1087,7 @@ index 14a16f3..07792b7 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -677,7 +667,7 @@ pub trait Read {
+@@ -677,7 +664,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1201,7 +1096,7 @@ index 14a16f3..07792b7 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -740,7 +730,6 @@ pub trait Read {
+@@ -740,7 +727,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1104,7 @@ index 14a16f3..07792b7 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -792,7 +781,6 @@ pub trait Read {
+@@ -792,7 +778,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1217,7 +1112,7 @@ index 14a16f3..07792b7 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -829,7 +817,6 @@ pub trait Read {
+@@ -829,7 +814,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1225,7 +1120,7 @@ index 14a16f3..07792b7 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -864,7 +851,6 @@ pub trait Read {
+@@ -864,7 +848,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1233,7 +1128,7 @@ index 14a16f3..07792b7 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -900,42 +886,77 @@ pub trait Read {
+@@ -900,22 +883,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1243,10 +1138,8 @@ index 14a16f3..07792b7 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1258,10 +1151,9 @@ index 14a16f3..07792b7 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1285,23 +1177,15 @@ index 14a16f3..07792b7 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -928,14 +941,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1314,41 +1198,31 @@ index 14a16f3..07792b7 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -945,7 +966,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -945,7 +956,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -958,31 +979,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -958,11 +968,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -975,14 +983,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1361,11 +1235,10 @@ index 14a16f3..07792b7 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -993,13 +1014,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -993,13 +999,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1379,7 +1252,7 @@ index 14a16f3..07792b7 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -1013,21 +1032,18 @@ impl Initializer {
+@@ -1013,21 +1017,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1401,7 +1274,7 @@ index 14a16f3..07792b7 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1081,7 +1097,6 @@ impl Initializer {
+@@ -1081,7 +1082,6 @@ impl Initializer {
  /// `write` in a loop until its entire input has been written.
  ///
  /// [`write_all`]: #method.write_all
@@ -1409,7 +1282,7 @@ index 14a16f3..07792b7 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1130,7 +1145,6 @@ pub trait Write {
+@@ -1130,7 +1130,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1417,16 +1290,15 @@ index 14a16f3..07792b7 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1141,7 +1155,7 @@ pub trait Write {
+@@ -1141,7 +1140,6 @@ pub trait Write {
      ///
      /// The default implementation calls `write` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          default_write_vectored(|b| self.write(b), bufs)
      }
-@@ -1169,7 +1183,6 @@ pub trait Write {
+@@ -1169,7 +1167,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1306,7 @@ index 14a16f3..07792b7 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1202,7 +1215,6 @@ pub trait Write {
+@@ -1202,7 +1199,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1442,7 +1314,7 @@ index 14a16f3..07792b7 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1254,7 +1266,6 @@ pub trait Write {
+@@ -1254,7 +1250,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1450,7 +1322,7 @@ index 14a16f3..07792b7 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1310,7 +1321,6 @@ pub trait Write {
+@@ -1310,7 +1305,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1458,7 +1330,7 @@ index 14a16f3..07792b7 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1340,7 +1350,6 @@ pub trait Write {
+@@ -1340,7 +1334,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1466,7 +1338,7 @@ index 14a16f3..07792b7 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1356,7 +1365,6 @@ pub trait Seek {
+@@ -1356,7 +1349,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1474,7 +1346,7 @@ index 14a16f3..07792b7 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  
      /// Returns the length of this stream (in bytes).
-@@ -1394,7 +1402,6 @@ pub trait Seek {
+@@ -1394,7 +1386,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1482,7 +1354,7 @@ index 14a16f3..07792b7 100644
      fn stream_len(&mut self) -> Result<u64> {
          let old_pos = self.stream_position()?;
          let len = self.seek(SeekFrom::End(0))?;
-@@ -1433,7 +1440,6 @@ pub trait Seek {
+@@ -1433,7 +1424,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1490,7 +1362,7 @@ index 14a16f3..07792b7 100644
      fn stream_position(&mut self) -> Result<u64> {
          self.seek(SeekFrom::Current(0))
      }
-@@ -1445,29 +1451,26 @@ pub trait Seek {
+@@ -1445,29 +1435,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1524,7 +1396,7 @@ index 14a16f3..07792b7 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1547,7 +1550,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1547,7 +1534,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1533,7 +1405,7 @@ index 14a16f3..07792b7 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1593,7 +1596,6 @@ pub trait BufRead: Read {
+@@ -1593,7 +1580,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1541,7 +1413,7 @@ index 14a16f3..07792b7 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1615,7 +1617,6 @@ pub trait BufRead: Read {
+@@ -1615,7 +1601,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1549,7 +1421,7 @@ index 14a16f3..07792b7 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1671,7 +1672,6 @@ pub trait BufRead: Read {
+@@ -1671,7 +1656,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1557,7 +1429,7 @@ index 14a16f3..07792b7 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1730,7 +1730,6 @@ pub trait BufRead: Read {
+@@ -1730,7 +1714,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1565,7 +1437,7 @@ index 14a16f3..07792b7 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1771,7 +1770,6 @@ pub trait BufRead: Read {
+@@ -1771,7 +1754,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1573,7 +1445,7 @@ index 14a16f3..07792b7 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1810,7 +1808,6 @@ pub trait BufRead: Read {
+@@ -1810,7 +1792,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1581,7 +1453,7 @@ index 14a16f3..07792b7 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1822,7 +1819,6 @@ pub trait BufRead: Read {
+@@ -1822,7 +1803,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1589,7 +1461,7 @@ index 14a16f3..07792b7 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1848,7 +1844,6 @@ impl<T, U> Chain<T, U> {
+@@ -1848,7 +1828,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1597,7 +1469,7 @@ index 14a16f3..07792b7 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1871,7 +1866,6 @@ impl<T, U> Chain<T, U> {
+@@ -1871,7 +1850,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1605,7 +1477,7 @@ index 14a16f3..07792b7 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1898,13 +1892,11 @@ impl<T, U> Chain<T, U> {
+@@ -1898,13 +1876,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1619,7 +1491,7 @@ index 14a16f3..07792b7 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1914,7 +1906,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1914,7 +1890,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1627,15 +1499,7 @@ index 14a16f3..07792b7 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1926,6 +1917,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1946,7 +1938,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1946,7 +1921,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1644,7 +1508,7 @@ index 14a16f3..07792b7 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1973,7 +1965,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1973,7 +1948,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1652,7 +1516,7 @@ index 14a16f3..07792b7 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -2008,7 +1999,6 @@ impl<T> Take<T> {
+@@ -2008,7 +1982,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1660,7 +1524,7 @@ index 14a16f3..07792b7 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -2034,7 +2024,6 @@ impl<T> Take<T> {
+@@ -2034,7 +2007,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1668,7 +1532,7 @@ index 14a16f3..07792b7 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -2059,7 +2048,6 @@ impl<T> Take<T> {
+@@ -2059,7 +2031,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1676,7 +1540,7 @@ index 14a16f3..07792b7 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -2084,7 +2072,6 @@ impl<T> Take<T> {
+@@ -2084,7 +2055,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1684,7 +1548,7 @@ index 14a16f3..07792b7 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2113,13 +2100,11 @@ impl<T> Take<T> {
+@@ -2113,13 +2083,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1698,16 +1562,16 @@ index 14a16f3..07792b7 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2136,15 +2121,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2137,6 +2105,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2144,7 +2113,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1715,7 +1579,7 @@ index 14a16f3..07792b7 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2171,13 +2150,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2171,13 +2140,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1729,7 +1593,7 @@ index 14a16f3..07792b7 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2201,14 +2178,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2201,14 +2168,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1746,7 +1610,7 @@ index 14a16f3..07792b7 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2233,13 +2210,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2233,13 +2200,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1789,8 +1653,8 @@ index 6aaf8f1..447ce47 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1859,15 +1723,7 @@ index 6aaf8f1..447ce47 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1875,7 +1731,7 @@ index 6aaf8f1..447ce47 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1883,7 +1739,7 @@ index 6aaf8f1..447ce47 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1894,12 +1750,7 @@ index 6aaf8f1..447ce47 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/b9adc3327ec7d2820ab2db8bb3cc2a0196a8375d.patch
+++ b/patches/b9adc3327ec7d2820ab2db8bb3cc2a0196a8375d.patch
@@ -1401,16 +1401,16 @@ index e263db2..2176464 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1907,15 +1856,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1908,6 +1857,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1915,7 +1865,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1418,7 +1418,7 @@ index e263db2..2176464 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1954,13 +1897,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1954,13 +1904,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1432,7 +1432,7 @@ index e263db2..2176464 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1976,14 +1917,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1976,14 +1924,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1449,7 +1449,7 @@ index e263db2..2176464 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2008,13 +1949,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2008,13 +1956,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/c0e8cf94103289c424c62ca48e1e3f56e352a84a.patch
+++ b/patches/c0e8cf94103289c424c62ca48e1e3f56e352a84a.patch
@@ -15,7 +15,7 @@ index 559a54d..bd888d2 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -311,21 +311,19 @@ diff --git a/cursor.rs b/cursor.rs
 index 873da08..3d39e57 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 873da08..3d39e57 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 873da08..3d39e57 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 873da08..3d39e57 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 873da08..3d39e57 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 873da08..3d39e57 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 873da08..3d39e57 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 873da08..3d39e57 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -214,14 +207,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -214,10 +206,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 873da08..3d39e57 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -236,7 +229,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -236,7 +227,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 873da08..3d39e57 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -247,12 +240,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -247,12 +238,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 873da08..3d39e57 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -264,6 +261,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -282,6 +280,7 @@ fn slice_write_vectored(
+@@ -282,6 +277,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 873da08..3d39e57 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -308,6 +307,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -308,6 +304,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 873da08..3d39e57 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -321,13 +321,13 @@ fn vec_write_vectored(
+@@ -321,7 +318,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -336,12 +336,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -336,7 +332,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -349,12 +350,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -349,7 +345,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -362,13 +364,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -362,8 +358,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 873da08..3d39e57 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index fdc5625..e4ce8b5 100644
 --- a/error.rs
@@ -836,7 +796,7 @@ diff --git a/impls.rs b/impls.rs
 index b286e40..7472d9c 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -844,8 +804,8 @@ index b286e40..7472d9c 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -858,14 +818,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -879,7 +832,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -887,12 +840,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -906,7 +854,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -915,14 +863,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -936,7 +877,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -945,12 +886,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -965,7 +901,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -186,7 +194,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
+@@ -186,7 +190,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -973,15 +909,7 @@ index b286e40..7472d9c 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -206,6 +213,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -245,6 +253,7 @@ impl Read for &[u8] {
+@@ -245,6 +248,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -989,7 +917,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -254,7 +263,7 @@ impl Read for &[u8] {
+@@ -254,7 +258,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -998,7 +926,7 @@ index b286e40..7472d9c 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -268,7 +277,6 @@ impl BufRead for &[u8] {
+@@ -268,7 +272,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1006,15 +934,7 @@ index b286e40..7472d9c 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -279,6 +287,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -307,7 +316,7 @@ impl Write for &mut [u8] {
+@@ -307,7 +310,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1023,14 +943,6 @@ index b286e40..7472d9c 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -315,6 +324,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index e3e2754..400eca6 100644
 --- a/mod.rs
@@ -1064,9 +976,9 @@ index e3e2754..400eca6 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1142,16 +1054,15 @@ index e3e2754..400eca6 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -530,7 +519,7 @@ pub trait Read {
+@@ -530,7 +519,6 @@ pub trait Read {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `read`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          match bufs.iter_mut().find(|b| !b.is_empty()) {
              Some(buf) => self.read(buf),
-@@ -560,7 +549,6 @@ pub trait Read {
+@@ -560,7 +548,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1159,7 +1070,7 @@ index e3e2754..400eca6 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -613,7 +601,7 @@ pub trait Read {
+@@ -613,7 +600,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1168,7 +1079,7 @@ index e3e2754..400eca6 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -656,7 +644,7 @@ pub trait Read {
+@@ -656,7 +643,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1177,7 +1088,7 @@ index e3e2754..400eca6 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -719,7 +707,6 @@ pub trait Read {
+@@ -719,7 +706,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1185,7 +1096,7 @@ index e3e2754..400eca6 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -771,7 +758,6 @@ pub trait Read {
+@@ -771,7 +757,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1193,7 +1104,7 @@ index e3e2754..400eca6 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -808,7 +794,6 @@ pub trait Read {
+@@ -808,7 +793,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1201,7 +1112,7 @@ index e3e2754..400eca6 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -843,7 +828,6 @@ pub trait Read {
+@@ -843,7 +827,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1120,7 @@ index e3e2754..400eca6 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -879,42 +863,77 @@ pub trait Read {
+@@ -879,22 +862,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1219,10 +1130,8 @@ index e3e2754..400eca6 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1234,10 +1143,9 @@ index e3e2754..400eca6 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1261,23 +1169,15 @@ index e3e2754..400eca6 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -907,14 +920,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1290,41 +1190,31 @@ index e3e2754..400eca6 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -924,7 +943,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -924,7 +935,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -937,31 +956,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -937,11 +947,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -954,14 +962,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1337,11 +1227,10 @@ index e3e2754..400eca6 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -972,13 +991,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -972,13 +978,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1355,7 +1244,7 @@ index e3e2754..400eca6 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -992,21 +1009,18 @@ impl Initializer {
+@@ -992,21 +996,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1377,7 +1266,7 @@ index e3e2754..400eca6 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1049,7 +1063,6 @@ impl Initializer {
+@@ -1049,7 +1050,6 @@ impl Initializer {
  ///     Ok(())
  /// }
  /// ```
@@ -1385,7 +1274,7 @@ index e3e2754..400eca6 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1098,7 +1111,6 @@ pub trait Write {
+@@ -1098,7 +1098,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1393,16 +1282,15 @@ index e3e2754..400eca6 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1109,7 +1121,7 @@ pub trait Write {
+@@ -1109,7 +1108,6 @@ pub trait Write {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `write`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          match bufs.iter().find(|b| !b.is_empty()) {
              Some(buf) => self.write(buf),
-@@ -1140,7 +1152,6 @@ pub trait Write {
+@@ -1140,7 +1138,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1410,7 +1298,7 @@ index e3e2754..400eca6 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1173,7 +1184,6 @@ pub trait Write {
+@@ -1173,7 +1170,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1418,7 +1306,7 @@ index e3e2754..400eca6 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1225,7 +1235,6 @@ pub trait Write {
+@@ -1225,7 +1221,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1426,7 +1314,7 @@ index e3e2754..400eca6 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1281,7 +1290,6 @@ pub trait Write {
+@@ -1281,7 +1276,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1322,7 @@ index e3e2754..400eca6 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1311,7 +1319,6 @@ pub trait Write {
+@@ -1311,7 +1305,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1442,7 +1330,7 @@ index e3e2754..400eca6 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1327,7 +1334,6 @@ pub trait Seek {
+@@ -1327,7 +1320,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1450,7 +1338,7 @@ index e3e2754..400eca6 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  }
  
-@@ -1337,29 +1343,26 @@ pub trait Seek {
+@@ -1337,29 +1329,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1484,7 +1372,7 @@ index e3e2754..400eca6 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1439,7 +1442,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1439,7 +1428,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1493,7 +1381,7 @@ index e3e2754..400eca6 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1485,7 +1488,6 @@ pub trait BufRead: Read {
+@@ -1485,7 +1474,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1501,7 +1389,7 @@ index e3e2754..400eca6 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1507,7 +1509,6 @@ pub trait BufRead: Read {
+@@ -1507,7 +1495,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1509,7 +1397,7 @@ index e3e2754..400eca6 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1563,7 +1564,6 @@ pub trait BufRead: Read {
+@@ -1563,7 +1550,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1517,7 +1405,7 @@ index e3e2754..400eca6 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1622,7 +1622,6 @@ pub trait BufRead: Read {
+@@ -1622,7 +1608,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1525,7 +1413,7 @@ index e3e2754..400eca6 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1663,7 +1662,6 @@ pub trait BufRead: Read {
+@@ -1663,7 +1648,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1533,7 +1421,7 @@ index e3e2754..400eca6 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1702,7 +1700,6 @@ pub trait BufRead: Read {
+@@ -1702,7 +1686,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1541,7 +1429,7 @@ index e3e2754..400eca6 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1714,7 +1711,6 @@ pub trait BufRead: Read {
+@@ -1714,7 +1697,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1549,7 +1437,7 @@ index e3e2754..400eca6 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1740,7 +1736,6 @@ impl<T, U> Chain<T, U> {
+@@ -1740,7 +1722,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1557,7 +1445,7 @@ index e3e2754..400eca6 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1763,7 +1758,6 @@ impl<T, U> Chain<T, U> {
+@@ -1763,7 +1744,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1565,7 +1453,7 @@ index e3e2754..400eca6 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1790,13 +1784,11 @@ impl<T, U> Chain<T, U> {
+@@ -1790,13 +1770,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1579,7 +1467,7 @@ index e3e2754..400eca6 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1806,7 +1798,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1806,7 +1784,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1587,15 +1475,7 @@ index e3e2754..400eca6 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1818,6 +1809,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1838,7 +1830,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1838,7 +1815,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1604,7 +1484,7 @@ index e3e2754..400eca6 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1865,7 +1857,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1865,7 +1842,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1612,7 +1492,7 @@ index e3e2754..400eca6 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -1900,7 +1891,6 @@ impl<T> Take<T> {
+@@ -1900,7 +1876,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1620,7 +1500,7 @@ index e3e2754..400eca6 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -1926,7 +1916,6 @@ impl<T> Take<T> {
+@@ -1926,7 +1901,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1628,7 +1508,7 @@ index e3e2754..400eca6 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -1951,7 +1940,6 @@ impl<T> Take<T> {
+@@ -1951,7 +1925,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1636,7 +1516,7 @@ index e3e2754..400eca6 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -1976,7 +1964,6 @@ impl<T> Take<T> {
+@@ -1976,7 +1949,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1644,7 +1524,7 @@ index e3e2754..400eca6 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2005,13 +1992,11 @@ impl<T> Take<T> {
+@@ -2005,13 +1977,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1658,16 +1538,16 @@ index e3e2754..400eca6 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2028,15 +2013,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2029,6 +1999,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2036,7 +2007,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1675,7 +1555,7 @@ index e3e2754..400eca6 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2063,13 +2042,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2063,13 +2034,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1689,7 +1569,7 @@ index e3e2754..400eca6 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2093,14 +2070,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2093,14 +2062,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1706,7 +1586,7 @@ index e3e2754..400eca6 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2125,13 +2102,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2125,13 +2094,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1749,8 +1629,8 @@ index 6aaf8f1..447ce47 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1819,15 +1699,7 @@ index 6aaf8f1..447ce47 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1835,7 +1707,7 @@ index 6aaf8f1..447ce47 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1843,7 +1715,7 @@ index 6aaf8f1..447ce47 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1854,12 +1726,7 @@ index 6aaf8f1..447ce47 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/c97d3d4dd174e8a80e9d0e55ea6f9a73aca60bf2.patch
+++ b/patches/c97d3d4dd174e8a80e9d0e55ea6f9a73aca60bf2.patch
@@ -15,7 +15,7 @@ index 4668e3e..4c125bd 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -311,21 +311,19 @@ diff --git a/cursor.rs b/cursor.rs
 index 247d45c..f13522d 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 247d45c..f13522d 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 247d45c..f13522d 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 247d45c..f13522d 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 247d45c..f13522d 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 247d45c..f13522d 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 247d45c..f13522d 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 247d45c..f13522d 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -222,14 +215,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -222,10 +214,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -244,7 +237,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -244,7 +235,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -255,12 +248,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -255,12 +246,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 247d45c..f13522d 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -272,6 +269,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -290,6 +288,7 @@ fn slice_write_vectored(
+@@ -290,6 +285,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 247d45c..f13522d 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -316,6 +315,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -316,6 +312,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 247d45c..f13522d 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -329,13 +329,13 @@ fn vec_write_vectored(
+@@ -329,7 +326,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -344,12 +344,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -344,7 +340,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -357,12 +358,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -357,7 +353,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -370,13 +372,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -370,8 +366,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 247d45c..f13522d 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index 614b791..e4ce8b5 100644
 --- a/error.rs
@@ -841,10 +801,10 @@ index 614b791..e4ce8b5 100644
      fn _is_sync_send<T: Sync+Send>() {}
      _is_sync_send::<Error>();
 diff --git a/impls.rs b/impls.rs
-index b286e40..7472d9c 100644
+index b286e40..17d1bdb 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -852,8 +812,8 @@ index b286e40..7472d9c 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -866,14 +826,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -887,7 +840,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -895,12 +848,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -914,7 +862,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -923,14 +871,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -944,7 +885,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -953,12 +894,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -973,7 +909,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -186,7 +194,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
+@@ -186,7 +190,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -981,15 +917,7 @@ index b286e40..7472d9c 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -206,6 +213,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -245,6 +253,7 @@ impl Read for &[u8] {
+@@ -245,6 +248,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -997,7 +925,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -254,7 +263,7 @@ impl Read for &[u8] {
+@@ -254,7 +258,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -1006,7 +934,7 @@ index b286e40..7472d9c 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -268,7 +277,6 @@ impl BufRead for &[u8] {
+@@ -268,7 +272,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1014,15 +942,7 @@ index b286e40..7472d9c 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -279,6 +287,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -307,7 +316,7 @@ impl Write for &mut [u8] {
+@@ -307,7 +310,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1031,16 +951,8 @@ index b286e40..7472d9c 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -315,6 +324,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
-index 7147b64..2059b5a 100644
+index 7147b64..b7d3943 100644
 --- a/mod.rs
 +++ b/mod.rs
 @@ -257,50 +257,38 @@
@@ -1072,9 +984,9 @@ index 7147b64..2059b5a 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1134,23 +1046,7 @@ index 7147b64..2059b5a 100644
  fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
                                                    buf: &mut Vec<u8>,
                                                    reservation_size: usize) -> Result<usize>
-@@ -390,6 +381,7 @@ fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
-     ret
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_read_vectored<F>(read: F, bufs: &mut [IoVecMut<'_>]) -> Result<usize>
- where
-     F: FnOnce(&mut [u8]) -> Result<usize>
-@@ -401,6 +393,7 @@ where
-     read(buf)
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_write_vectored<F>(write: F, bufs: &[IoVec<'_>]) -> Result<usize>
- where
-     F: FnOnce(&[u8]) -> Result<usize>
-@@ -484,7 +477,6 @@ where
+@@ -484,7 +475,6 @@ where
  /// [`BufReader`]: struct.BufReader.html
  /// [`&str`]: ../../std/primitive.str.html
  /// [slice]: ../../std/primitive.slice.html
@@ -1158,7 +1054,7 @@ index 7147b64..2059b5a 100644
  #[doc(spotlight)]
  pub trait Read {
      /// Pull some bytes from this source into the specified buffer, returning
-@@ -541,7 +533,6 @@ pub trait Read {
+@@ -541,7 +531,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1166,16 +1062,15 @@ index 7147b64..2059b5a 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -552,7 +543,7 @@ pub trait Read {
+@@ -552,7 +541,6 @@ pub trait Read {
      ///
      /// The default implementation calls `read` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          default_read_vectored(|b| self.read(b), bufs)
      }
-@@ -579,7 +570,6 @@ pub trait Read {
+@@ -579,7 +567,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1183,7 +1078,7 @@ index 7147b64..2059b5a 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -632,7 +622,7 @@ pub trait Read {
+@@ -632,7 +619,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1192,7 +1087,7 @@ index 7147b64..2059b5a 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -675,7 +665,7 @@ pub trait Read {
+@@ -675,7 +662,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1201,7 +1096,7 @@ index 7147b64..2059b5a 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -738,7 +728,6 @@ pub trait Read {
+@@ -738,7 +725,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1104,7 @@ index 7147b64..2059b5a 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -790,7 +779,6 @@ pub trait Read {
+@@ -790,7 +776,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1217,7 +1112,7 @@ index 7147b64..2059b5a 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -827,7 +815,6 @@ pub trait Read {
+@@ -827,7 +812,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1225,7 +1120,7 @@ index 7147b64..2059b5a 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -862,7 +849,6 @@ pub trait Read {
+@@ -862,7 +846,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1233,7 +1128,7 @@ index 7147b64..2059b5a 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -898,42 +884,77 @@ pub trait Read {
+@@ -898,22 +881,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1243,10 +1138,8 @@ index 7147b64..2059b5a 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1258,10 +1151,9 @@ index 7147b64..2059b5a 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1285,23 +1177,15 @@ index 7147b64..2059b5a 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -926,14 +939,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1314,41 +1198,31 @@ index 7147b64..2059b5a 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -943,7 +964,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -943,7 +954,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -956,31 +977,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -956,11 +966,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -973,14 +981,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1361,11 +1235,10 @@ index 7147b64..2059b5a 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -991,13 +1012,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -991,13 +997,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1379,7 +1252,7 @@ index 7147b64..2059b5a 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -1011,21 +1030,18 @@ impl Initializer {
+@@ -1011,21 +1015,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1401,7 +1274,7 @@ index 7147b64..2059b5a 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1068,7 +1084,6 @@ impl Initializer {
+@@ -1068,7 +1069,6 @@ impl Initializer {
  ///     Ok(())
  /// }
  /// ```
@@ -1409,7 +1282,7 @@ index 7147b64..2059b5a 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1117,7 +1132,6 @@ pub trait Write {
+@@ -1117,7 +1117,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1417,16 +1290,15 @@ index 7147b64..2059b5a 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1128,7 +1142,7 @@ pub trait Write {
+@@ -1128,7 +1127,6 @@ pub trait Write {
      ///
      /// The default implementation calls `write` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          default_write_vectored(|b| self.write(b), bufs)
      }
-@@ -1156,7 +1170,6 @@ pub trait Write {
+@@ -1156,7 +1154,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1306,7 @@ index 7147b64..2059b5a 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1189,7 +1202,6 @@ pub trait Write {
+@@ -1189,7 +1186,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1442,7 +1314,7 @@ index 7147b64..2059b5a 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1241,7 +1253,6 @@ pub trait Write {
+@@ -1241,7 +1237,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1450,7 +1322,7 @@ index 7147b64..2059b5a 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1297,7 +1308,6 @@ pub trait Write {
+@@ -1297,7 +1292,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1458,7 +1330,7 @@ index 7147b64..2059b5a 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1327,7 +1337,6 @@ pub trait Write {
+@@ -1327,7 +1321,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1466,7 +1338,7 @@ index 7147b64..2059b5a 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1343,7 +1352,6 @@ pub trait Seek {
+@@ -1343,7 +1336,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1474,7 +1346,7 @@ index 7147b64..2059b5a 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  
      /// Returns the length of this stream (in bytes).
-@@ -1381,7 +1389,6 @@ pub trait Seek {
+@@ -1381,7 +1373,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1482,7 +1354,7 @@ index 7147b64..2059b5a 100644
      fn stream_len(&mut self) -> Result<u64> {
          let old_pos = self.stream_position()?;
          let len = self.seek(SeekFrom::End(0))?;
-@@ -1420,7 +1427,6 @@ pub trait Seek {
+@@ -1420,7 +1411,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1490,7 +1362,7 @@ index 7147b64..2059b5a 100644
      fn stream_position(&mut self) -> Result<u64> {
          self.seek(SeekFrom::Current(0))
      }
-@@ -1432,29 +1438,26 @@ pub trait Seek {
+@@ -1432,29 +1422,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1524,7 +1396,7 @@ index 7147b64..2059b5a 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1534,7 +1537,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1534,7 +1521,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1533,7 +1405,7 @@ index 7147b64..2059b5a 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1580,7 +1583,6 @@ pub trait BufRead: Read {
+@@ -1580,7 +1567,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1541,7 +1413,7 @@ index 7147b64..2059b5a 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1602,7 +1604,6 @@ pub trait BufRead: Read {
+@@ -1602,7 +1588,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1549,7 +1421,7 @@ index 7147b64..2059b5a 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1658,7 +1659,6 @@ pub trait BufRead: Read {
+@@ -1658,7 +1643,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1557,7 +1429,7 @@ index 7147b64..2059b5a 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1717,7 +1717,6 @@ pub trait BufRead: Read {
+@@ -1717,7 +1701,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1565,7 +1437,7 @@ index 7147b64..2059b5a 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1758,7 +1757,6 @@ pub trait BufRead: Read {
+@@ -1758,7 +1741,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1573,7 +1445,7 @@ index 7147b64..2059b5a 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1797,7 +1795,6 @@ pub trait BufRead: Read {
+@@ -1797,7 +1779,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1581,7 +1453,7 @@ index 7147b64..2059b5a 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1809,7 +1806,6 @@ pub trait BufRead: Read {
+@@ -1809,7 +1790,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1589,7 +1461,7 @@ index 7147b64..2059b5a 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1835,7 +1831,6 @@ impl<T, U> Chain<T, U> {
+@@ -1835,7 +1815,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1597,7 +1469,7 @@ index 7147b64..2059b5a 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1858,7 +1853,6 @@ impl<T, U> Chain<T, U> {
+@@ -1858,7 +1837,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1605,7 +1477,7 @@ index 7147b64..2059b5a 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1885,13 +1879,11 @@ impl<T, U> Chain<T, U> {
+@@ -1885,13 +1863,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1619,7 +1491,7 @@ index 7147b64..2059b5a 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1901,7 +1893,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1901,7 +1877,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1627,15 +1499,7 @@ index 7147b64..2059b5a 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1913,6 +1904,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1933,7 +1925,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1933,7 +1908,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1644,7 +1508,7 @@ index 7147b64..2059b5a 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1960,7 +1952,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1960,7 +1935,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1652,7 +1516,7 @@ index 7147b64..2059b5a 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -1995,7 +1986,6 @@ impl<T> Take<T> {
+@@ -1995,7 +1969,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1660,7 +1524,7 @@ index 7147b64..2059b5a 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -2021,7 +2011,6 @@ impl<T> Take<T> {
+@@ -2021,7 +1994,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1668,7 +1532,7 @@ index 7147b64..2059b5a 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -2046,7 +2035,6 @@ impl<T> Take<T> {
+@@ -2046,7 +2018,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1676,7 +1540,7 @@ index 7147b64..2059b5a 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -2071,7 +2059,6 @@ impl<T> Take<T> {
+@@ -2071,7 +2042,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1684,7 +1548,7 @@ index 7147b64..2059b5a 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2100,13 +2087,11 @@ impl<T> Take<T> {
+@@ -2100,13 +2070,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1698,16 +1562,16 @@ index 7147b64..2059b5a 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2123,15 +2108,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2124,6 +2092,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2131,7 +2100,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1715,7 +1579,7 @@ index 7147b64..2059b5a 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2158,13 +2137,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2158,13 +2127,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1729,7 +1593,7 @@ index 7147b64..2059b5a 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2188,14 +2165,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2188,14 +2155,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1746,7 +1610,7 @@ index 7147b64..2059b5a 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2220,13 +2197,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2220,13 +2187,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1779,7 +1643,7 @@ index 2e19edf..66294a3 100644
 +#[cfg(feature="collections")] pub use alloc::boxed::Box;
 +#[cfg(feature="collections")] pub use collections::vec::Vec;
 diff --git a/util.rs b/util.rs
-index 6aaf8f1..447ce47 100644
+index 6aaf8f1..15ce0af 100644
 --- a/util.rs
 +++ b/util.rs
 @@ -1,8 +1,9 @@
@@ -1789,8 +1653,8 @@ index 6aaf8f1..447ce47 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1859,15 +1723,7 @@ index 6aaf8f1..447ce47 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1875,7 +1731,7 @@ index 6aaf8f1..447ce47 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1883,7 +1739,7 @@ index 6aaf8f1..447ce47 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1894,12 +1750,7 @@ index 6aaf8f1..447ce47 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/cf9fd6074da321b353a755359fac10cd28ed251d.patch
+++ b/patches/cf9fd6074da321b353a755359fac10cd28ed251d.patch
@@ -970,8 +970,8 @@ index 5137a94..da64ab7 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+use core::ptr;
 +use core::slice;
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1412,16 +1412,16 @@ index 5137a94..da64ab7 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1908,15 +1857,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1909,6 +1858,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1916,7 +1866,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1429,7 +1429,7 @@ index 5137a94..da64ab7 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1943,13 +1886,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -1943,13 +1893,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1443,7 +1443,7 @@ index 5137a94..da64ab7 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1973,14 +1914,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1973,14 +1921,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1460,7 +1460,7 @@ index 5137a94..da64ab7 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2005,13 +1946,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2005,13 +1953,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/d3f30c30eaf56b69cf458656c1a84a931d1108a9.patch
+++ b/patches/d3f30c30eaf56b69cf458656c1a84a931d1108a9.patch
@@ -15,7 +15,7 @@ index a14c10d..3e78c01 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -311,21 +311,19 @@ diff --git a/cursor.rs b/cursor.rs
 index 873da08..3d39e57 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 873da08..3d39e57 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 873da08..3d39e57 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 873da08..3d39e57 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 873da08..3d39e57 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 873da08..3d39e57 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 873da08..3d39e57 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 873da08..3d39e57 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -214,14 +207,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -214,10 +206,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 873da08..3d39e57 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -236,7 +229,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -236,7 +227,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 873da08..3d39e57 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -247,12 +240,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -247,12 +238,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 873da08..3d39e57 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -264,6 +261,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -282,6 +280,7 @@ fn slice_write_vectored(
+@@ -282,6 +277,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 873da08..3d39e57 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -308,6 +307,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -308,6 +304,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 873da08..3d39e57 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -321,13 +321,13 @@ fn vec_write_vectored(
+@@ -321,7 +318,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -336,12 +336,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -336,7 +332,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -349,12 +350,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -349,7 +345,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -362,13 +364,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -362,8 +358,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 873da08..3d39e57 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index 614b791..e4ce8b5 100644
 --- a/error.rs
@@ -841,10 +801,10 @@ index 614b791..e4ce8b5 100644
      fn _is_sync_send<T: Sync+Send>() {}
      _is_sync_send::<Error>();
 diff --git a/impls.rs b/impls.rs
-index b286e40..7472d9c 100644
+index b286e40..17d1bdb 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -852,8 +812,8 @@ index b286e40..7472d9c 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -866,14 +826,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -887,7 +840,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -895,12 +848,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -914,7 +862,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -923,14 +871,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -944,7 +885,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -953,12 +894,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -973,7 +909,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -186,7 +194,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
+@@ -186,7 +190,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -981,15 +917,7 @@ index b286e40..7472d9c 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -206,6 +213,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -245,6 +253,7 @@ impl Read for &[u8] {
+@@ -245,6 +248,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -997,7 +925,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -254,7 +263,7 @@ impl Read for &[u8] {
+@@ -254,7 +258,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -1006,7 +934,7 @@ index b286e40..7472d9c 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -268,7 +277,6 @@ impl BufRead for &[u8] {
+@@ -268,7 +272,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1014,15 +942,7 @@ index b286e40..7472d9c 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -279,6 +287,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -307,7 +316,7 @@ impl Write for &mut [u8] {
+@@ -307,7 +310,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1031,14 +951,6 @@ index b286e40..7472d9c 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -315,6 +324,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index 1a2152a..85652f4 100644
 --- a/mod.rs
@@ -1072,9 +984,9 @@ index 1a2152a..85652f4 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1134,23 +1046,7 @@ index 1a2152a..85652f4 100644
  fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
                                                    buf: &mut Vec<u8>,
                                                    reservation_size: usize) -> Result<usize>
-@@ -390,6 +381,7 @@ fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
-     ret
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_read_vectored<F>(read: F, bufs: &mut [IoVecMut<'_>]) -> Result<usize>
- where
-     F: FnOnce(&mut [u8]) -> Result<usize>
-@@ -401,6 +393,7 @@ where
-     read(buf)
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_write_vectored<F>(write: F, bufs: &[IoVec<'_>]) -> Result<usize>
- where
-     F: FnOnce(&[u8]) -> Result<usize>
-@@ -484,7 +477,6 @@ where
+@@ -484,7 +475,6 @@ where
  /// [`BufReader`]: struct.BufReader.html
  /// [`&str`]: ../../std/primitive.str.html
  /// [slice]: ../../std/primitive.slice.html
@@ -1158,7 +1054,7 @@ index 1a2152a..85652f4 100644
  #[doc(spotlight)]
  pub trait Read {
      /// Pull some bytes from this source into the specified buffer, returning
-@@ -541,7 +533,6 @@ pub trait Read {
+@@ -541,7 +531,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1166,16 +1062,15 @@ index 1a2152a..85652f4 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -552,7 +543,7 @@ pub trait Read {
+@@ -552,7 +541,6 @@ pub trait Read {
      ///
      /// The default implementation calls `read` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          default_read_vectored(|b| self.read(b), bufs)
      }
-@@ -579,7 +570,6 @@ pub trait Read {
+@@ -579,7 +567,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1183,7 +1078,7 @@ index 1a2152a..85652f4 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -632,7 +622,7 @@ pub trait Read {
+@@ -632,7 +619,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1192,7 +1087,7 @@ index 1a2152a..85652f4 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -675,7 +665,7 @@ pub trait Read {
+@@ -675,7 +662,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1201,7 +1096,7 @@ index 1a2152a..85652f4 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -738,7 +728,6 @@ pub trait Read {
+@@ -738,7 +725,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1104,7 @@ index 1a2152a..85652f4 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -790,7 +779,6 @@ pub trait Read {
+@@ -790,7 +776,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1217,7 +1112,7 @@ index 1a2152a..85652f4 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -827,7 +815,6 @@ pub trait Read {
+@@ -827,7 +812,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1225,7 +1120,7 @@ index 1a2152a..85652f4 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -862,7 +849,6 @@ pub trait Read {
+@@ -862,7 +846,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1233,7 +1128,7 @@ index 1a2152a..85652f4 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -898,42 +884,77 @@ pub trait Read {
+@@ -898,22 +881,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1243,10 +1138,8 @@ index 1a2152a..85652f4 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1258,10 +1151,9 @@ index 1a2152a..85652f4 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1285,23 +1177,15 @@ index 1a2152a..85652f4 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -926,14 +939,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1314,41 +1198,31 @@ index 1a2152a..85652f4 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -943,7 +964,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -943,7 +954,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -956,31 +977,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -956,11 +966,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -973,14 +981,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1361,11 +1235,10 @@ index 1a2152a..85652f4 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -991,13 +1012,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -991,13 +997,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1379,7 +1252,7 @@ index 1a2152a..85652f4 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -1011,21 +1030,18 @@ impl Initializer {
+@@ -1011,21 +1015,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1401,7 +1274,7 @@ index 1a2152a..85652f4 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1068,7 +1084,6 @@ impl Initializer {
+@@ -1068,7 +1069,6 @@ impl Initializer {
  ///     Ok(())
  /// }
  /// ```
@@ -1409,7 +1282,7 @@ index 1a2152a..85652f4 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1117,7 +1132,6 @@ pub trait Write {
+@@ -1117,7 +1117,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1417,16 +1290,15 @@ index 1a2152a..85652f4 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1128,7 +1142,7 @@ pub trait Write {
+@@ -1128,7 +1127,6 @@ pub trait Write {
      ///
      /// The default implementation calls `write` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          default_write_vectored(|b| self.write(b), bufs)
      }
-@@ -1156,7 +1170,6 @@ pub trait Write {
+@@ -1156,7 +1154,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1306,7 @@ index 1a2152a..85652f4 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1189,7 +1202,6 @@ pub trait Write {
+@@ -1189,7 +1186,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1442,7 +1314,7 @@ index 1a2152a..85652f4 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1241,7 +1253,6 @@ pub trait Write {
+@@ -1241,7 +1237,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1450,7 +1322,7 @@ index 1a2152a..85652f4 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1297,7 +1308,6 @@ pub trait Write {
+@@ -1297,7 +1292,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1458,7 +1330,7 @@ index 1a2152a..85652f4 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1327,7 +1337,6 @@ pub trait Write {
+@@ -1327,7 +1321,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1466,7 +1338,7 @@ index 1a2152a..85652f4 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1343,7 +1352,6 @@ pub trait Seek {
+@@ -1343,7 +1336,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1474,7 +1346,7 @@ index 1a2152a..85652f4 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  }
  
-@@ -1353,29 +1361,26 @@ pub trait Seek {
+@@ -1353,29 +1345,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1508,7 +1380,7 @@ index 1a2152a..85652f4 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1455,7 +1460,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1455,7 +1444,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1517,7 +1389,7 @@ index 1a2152a..85652f4 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1501,7 +1506,6 @@ pub trait BufRead: Read {
+@@ -1501,7 +1490,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1525,7 +1397,7 @@ index 1a2152a..85652f4 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1523,7 +1527,6 @@ pub trait BufRead: Read {
+@@ -1523,7 +1511,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1533,7 +1405,7 @@ index 1a2152a..85652f4 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1579,7 +1582,6 @@ pub trait BufRead: Read {
+@@ -1579,7 +1566,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1541,7 +1413,7 @@ index 1a2152a..85652f4 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1638,7 +1640,6 @@ pub trait BufRead: Read {
+@@ -1638,7 +1624,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1549,7 +1421,7 @@ index 1a2152a..85652f4 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1679,7 +1680,6 @@ pub trait BufRead: Read {
+@@ -1679,7 +1664,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1557,7 +1429,7 @@ index 1a2152a..85652f4 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1718,7 +1718,6 @@ pub trait BufRead: Read {
+@@ -1718,7 +1702,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1565,7 +1437,7 @@ index 1a2152a..85652f4 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1730,7 +1729,6 @@ pub trait BufRead: Read {
+@@ -1730,7 +1713,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1573,7 +1445,7 @@ index 1a2152a..85652f4 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1756,7 +1754,6 @@ impl<T, U> Chain<T, U> {
+@@ -1756,7 +1738,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1581,7 +1453,7 @@ index 1a2152a..85652f4 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1779,7 +1776,6 @@ impl<T, U> Chain<T, U> {
+@@ -1779,7 +1760,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1589,7 +1461,7 @@ index 1a2152a..85652f4 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1806,13 +1802,11 @@ impl<T, U> Chain<T, U> {
+@@ -1806,13 +1786,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1603,7 +1475,7 @@ index 1a2152a..85652f4 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1822,7 +1816,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1822,7 +1800,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1611,15 +1483,7 @@ index 1a2152a..85652f4 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1834,6 +1827,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1854,7 +1848,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1854,7 +1831,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1628,7 +1492,7 @@ index 1a2152a..85652f4 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1881,7 +1875,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1881,7 +1858,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1636,7 +1500,7 @@ index 1a2152a..85652f4 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -1916,7 +1909,6 @@ impl<T> Take<T> {
+@@ -1916,7 +1892,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1644,7 +1508,7 @@ index 1a2152a..85652f4 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -1942,7 +1934,6 @@ impl<T> Take<T> {
+@@ -1942,7 +1917,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1652,7 +1516,7 @@ index 1a2152a..85652f4 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -1967,7 +1958,6 @@ impl<T> Take<T> {
+@@ -1967,7 +1941,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1660,7 +1524,7 @@ index 1a2152a..85652f4 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -1992,7 +1982,6 @@ impl<T> Take<T> {
+@@ -1992,7 +1965,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1668,7 +1532,7 @@ index 1a2152a..85652f4 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2021,13 +2010,11 @@ impl<T> Take<T> {
+@@ -2021,13 +1993,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1682,16 +1546,16 @@ index 1a2152a..85652f4 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2044,15 +2031,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2045,6 +2015,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2052,7 +2023,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1699,7 +1563,7 @@ index 1a2152a..85652f4 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2079,13 +2060,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2079,13 +2050,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1713,7 +1577,7 @@ index 1a2152a..85652f4 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2109,14 +2088,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2109,14 +2078,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1730,7 +1594,7 @@ index 1a2152a..85652f4 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2141,13 +2120,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2141,13 +2110,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1773,8 +1637,8 @@ index 6aaf8f1..447ce47 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1843,15 +1707,7 @@ index 6aaf8f1..447ce47 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1859,7 +1715,7 @@ index 6aaf8f1..447ce47 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1867,7 +1723,7 @@ index 6aaf8f1..447ce47 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1878,12 +1734,7 @@ index 6aaf8f1..447ce47 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/d403cd787c98610cf5287301820ad3353b35481d.patch
+++ b/patches/d403cd787c98610cf5287301820ad3353b35481d.patch
@@ -15,7 +15,7 @@ index 441f6b9..540d4aa 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -311,21 +311,19 @@ diff --git a/cursor.rs b/cursor.rs
 index 247d45c..f13522d 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 247d45c..f13522d 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 247d45c..f13522d 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 247d45c..f13522d 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 247d45c..f13522d 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 247d45c..f13522d 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 247d45c..f13522d 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 247d45c..f13522d 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -222,14 +215,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -222,10 +214,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -244,7 +237,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -244,7 +235,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 247d45c..f13522d 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -255,12 +248,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -255,12 +246,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 247d45c..f13522d 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -272,6 +269,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -290,6 +288,7 @@ fn slice_write_vectored(
+@@ -290,6 +285,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 247d45c..f13522d 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -316,6 +315,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -316,6 +312,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 247d45c..f13522d 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -329,13 +329,13 @@ fn vec_write_vectored(
+@@ -329,7 +326,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -344,12 +344,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -344,7 +340,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -357,12 +358,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -357,7 +353,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 247d45c..f13522d 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -370,13 +372,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -370,8 +366,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 247d45c..f13522d 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index 614b791..e4ce8b5 100644
 --- a/error.rs
@@ -844,7 +804,7 @@ diff --git a/impls.rs b/impls.rs
 index b286e40..7472d9c 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -852,8 +812,8 @@ index b286e40..7472d9c 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -866,14 +826,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -887,7 +840,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -895,12 +848,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -914,7 +862,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -923,14 +871,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -944,7 +885,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -953,12 +894,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -973,7 +909,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -186,7 +194,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
+@@ -186,7 +190,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -981,15 +917,7 @@ index b286e40..7472d9c 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -206,6 +213,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -245,6 +253,7 @@ impl Read for &[u8] {
+@@ -245,6 +248,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -997,7 +925,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -254,7 +263,7 @@ impl Read for &[u8] {
+@@ -254,7 +258,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -1006,7 +934,7 @@ index b286e40..7472d9c 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -268,7 +277,6 @@ impl BufRead for &[u8] {
+@@ -268,7 +272,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1014,15 +942,7 @@ index b286e40..7472d9c 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -279,6 +287,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -307,7 +316,7 @@ impl Write for &mut [u8] {
+@@ -307,7 +310,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1031,14 +951,6 @@ index b286e40..7472d9c 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -315,6 +324,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index 7147b64..2059b5a 100644
 --- a/mod.rs
@@ -1072,9 +984,9 @@ index 7147b64..2059b5a 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1134,23 +1046,7 @@ index 7147b64..2059b5a 100644
  fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
                                                    buf: &mut Vec<u8>,
                                                    reservation_size: usize) -> Result<usize>
-@@ -390,6 +381,7 @@ fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
-     ret
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_read_vectored<F>(read: F, bufs: &mut [IoVecMut<'_>]) -> Result<usize>
- where
-     F: FnOnce(&mut [u8]) -> Result<usize>
-@@ -401,6 +393,7 @@ where
-     read(buf)
- }
- 
-+#[cfg(feature="collections")]
- pub(crate) fn default_write_vectored<F>(write: F, bufs: &[IoVec<'_>]) -> Result<usize>
- where
-     F: FnOnce(&[u8]) -> Result<usize>
-@@ -484,7 +477,6 @@ where
+@@ -484,7 +475,6 @@ where
  /// [`BufReader`]: struct.BufReader.html
  /// [`&str`]: ../../std/primitive.str.html
  /// [slice]: ../../std/primitive.slice.html
@@ -1158,7 +1054,7 @@ index 7147b64..2059b5a 100644
  #[doc(spotlight)]
  pub trait Read {
      /// Pull some bytes from this source into the specified buffer, returning
-@@ -541,7 +533,6 @@ pub trait Read {
+@@ -541,7 +531,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1166,16 +1062,15 @@ index 7147b64..2059b5a 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -552,7 +543,7 @@ pub trait Read {
+@@ -552,7 +541,6 @@ pub trait Read {
      ///
      /// The default implementation calls `read` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          default_read_vectored(|b| self.read(b), bufs)
      }
-@@ -579,7 +570,6 @@ pub trait Read {
+@@ -579,7 +567,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1183,7 +1078,7 @@ index 7147b64..2059b5a 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -632,7 +622,7 @@ pub trait Read {
+@@ -632,7 +619,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1192,7 +1087,7 @@ index 7147b64..2059b5a 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -675,7 +665,7 @@ pub trait Read {
+@@ -675,7 +662,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1201,7 +1096,7 @@ index 7147b64..2059b5a 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -738,7 +728,6 @@ pub trait Read {
+@@ -738,7 +725,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1104,7 @@ index 7147b64..2059b5a 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -790,7 +779,6 @@ pub trait Read {
+@@ -790,7 +776,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1217,7 +1112,7 @@ index 7147b64..2059b5a 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -827,7 +815,6 @@ pub trait Read {
+@@ -827,7 +812,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1225,7 +1120,7 @@ index 7147b64..2059b5a 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -862,7 +849,6 @@ pub trait Read {
+@@ -862,7 +846,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1233,7 +1128,7 @@ index 7147b64..2059b5a 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -898,42 +884,77 @@ pub trait Read {
+@@ -898,22 +881,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1243,10 +1138,8 @@ index 7147b64..2059b5a 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1258,10 +1151,9 @@ index 7147b64..2059b5a 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1285,23 +1177,15 @@ index 7147b64..2059b5a 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -926,14 +939,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1314,41 +1198,31 @@ index 7147b64..2059b5a 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -943,7 +964,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -943,7 +954,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -956,31 +977,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -956,11 +966,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -973,14 +981,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1361,11 +1235,10 @@ index 7147b64..2059b5a 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -991,13 +1012,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -991,13 +997,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1379,7 +1252,7 @@ index 7147b64..2059b5a 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -1011,21 +1030,18 @@ impl Initializer {
+@@ -1011,21 +1015,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1401,7 +1274,7 @@ index 7147b64..2059b5a 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1068,7 +1084,6 @@ impl Initializer {
+@@ -1068,7 +1069,6 @@ impl Initializer {
  ///     Ok(())
  /// }
  /// ```
@@ -1409,7 +1282,7 @@ index 7147b64..2059b5a 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1117,7 +1132,6 @@ pub trait Write {
+@@ -1117,7 +1117,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1417,16 +1290,15 @@ index 7147b64..2059b5a 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1128,7 +1142,7 @@ pub trait Write {
+@@ -1128,7 +1127,6 @@ pub trait Write {
      ///
      /// The default implementation calls `write` with either the first nonempty
      /// buffer provided, or an empty one if none exists.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          default_write_vectored(|b| self.write(b), bufs)
      }
-@@ -1156,7 +1170,6 @@ pub trait Write {
+@@ -1156,7 +1154,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1306,7 @@ index 7147b64..2059b5a 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1189,7 +1202,6 @@ pub trait Write {
+@@ -1189,7 +1186,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1442,7 +1314,7 @@ index 7147b64..2059b5a 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1241,7 +1253,6 @@ pub trait Write {
+@@ -1241,7 +1237,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1450,7 +1322,7 @@ index 7147b64..2059b5a 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1297,7 +1308,6 @@ pub trait Write {
+@@ -1297,7 +1292,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1458,7 +1330,7 @@ index 7147b64..2059b5a 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1327,7 +1337,6 @@ pub trait Write {
+@@ -1327,7 +1321,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1466,7 +1338,7 @@ index 7147b64..2059b5a 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1343,7 +1352,6 @@ pub trait Seek {
+@@ -1343,7 +1336,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1474,7 +1346,7 @@ index 7147b64..2059b5a 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  
      /// Returns the length of this stream (in bytes).
-@@ -1381,7 +1389,6 @@ pub trait Seek {
+@@ -1381,7 +1373,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1482,7 +1354,7 @@ index 7147b64..2059b5a 100644
      fn stream_len(&mut self) -> Result<u64> {
          let old_pos = self.stream_position()?;
          let len = self.seek(SeekFrom::End(0))?;
-@@ -1420,7 +1427,6 @@ pub trait Seek {
+@@ -1420,7 +1411,6 @@ pub trait Seek {
      ///     Ok(())
      /// }
      /// ```
@@ -1490,7 +1362,7 @@ index 7147b64..2059b5a 100644
      fn stream_position(&mut self) -> Result<u64> {
          self.seek(SeekFrom::Current(0))
      }
-@@ -1432,29 +1438,26 @@ pub trait Seek {
+@@ -1432,29 +1422,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1524,7 +1396,7 @@ index 7147b64..2059b5a 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1534,7 +1537,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1534,7 +1521,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1533,7 +1405,7 @@ index 7147b64..2059b5a 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1580,7 +1583,6 @@ pub trait BufRead: Read {
+@@ -1580,7 +1567,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1541,7 +1413,7 @@ index 7147b64..2059b5a 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1602,7 +1604,6 @@ pub trait BufRead: Read {
+@@ -1602,7 +1588,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1549,7 +1421,7 @@ index 7147b64..2059b5a 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1658,7 +1659,6 @@ pub trait BufRead: Read {
+@@ -1658,7 +1643,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1557,7 +1429,7 @@ index 7147b64..2059b5a 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1717,7 +1717,6 @@ pub trait BufRead: Read {
+@@ -1717,7 +1701,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1565,7 +1437,7 @@ index 7147b64..2059b5a 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1758,7 +1757,6 @@ pub trait BufRead: Read {
+@@ -1758,7 +1741,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1573,7 +1445,7 @@ index 7147b64..2059b5a 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1797,7 +1795,6 @@ pub trait BufRead: Read {
+@@ -1797,7 +1779,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1581,7 +1453,7 @@ index 7147b64..2059b5a 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1809,7 +1806,6 @@ pub trait BufRead: Read {
+@@ -1809,7 +1790,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1589,7 +1461,7 @@ index 7147b64..2059b5a 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1835,7 +1831,6 @@ impl<T, U> Chain<T, U> {
+@@ -1835,7 +1815,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1597,7 +1469,7 @@ index 7147b64..2059b5a 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1858,7 +1853,6 @@ impl<T, U> Chain<T, U> {
+@@ -1858,7 +1837,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1605,7 +1477,7 @@ index 7147b64..2059b5a 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1885,13 +1879,11 @@ impl<T, U> Chain<T, U> {
+@@ -1885,13 +1863,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1619,7 +1491,7 @@ index 7147b64..2059b5a 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1901,7 +1893,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1901,7 +1877,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1627,15 +1499,7 @@ index 7147b64..2059b5a 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1913,6 +1904,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1933,7 +1925,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1933,7 +1908,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1644,7 +1508,7 @@ index 7147b64..2059b5a 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1960,7 +1952,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1960,7 +1935,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1652,7 +1516,7 @@ index 7147b64..2059b5a 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -1995,7 +1986,6 @@ impl<T> Take<T> {
+@@ -1995,7 +1969,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1660,7 +1524,7 @@ index 7147b64..2059b5a 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -2021,7 +2011,6 @@ impl<T> Take<T> {
+@@ -2021,7 +1994,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1668,7 +1532,7 @@ index 7147b64..2059b5a 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -2046,7 +2035,6 @@ impl<T> Take<T> {
+@@ -2046,7 +2018,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1676,7 +1540,7 @@ index 7147b64..2059b5a 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -2071,7 +2059,6 @@ impl<T> Take<T> {
+@@ -2071,7 +2042,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1684,7 +1548,7 @@ index 7147b64..2059b5a 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2100,13 +2087,11 @@ impl<T> Take<T> {
+@@ -2100,13 +2070,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1698,16 +1562,16 @@ index 7147b64..2059b5a 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2123,15 +2108,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2124,6 +2092,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2131,7 +2100,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1715,7 +1579,7 @@ index 7147b64..2059b5a 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2158,13 +2137,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2158,13 +2127,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1729,7 +1593,7 @@ index 7147b64..2059b5a 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2188,14 +2165,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2188,14 +2155,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1746,7 +1610,7 @@ index 7147b64..2059b5a 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2220,13 +2197,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2220,13 +2187,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1789,8 +1653,8 @@ index 6aaf8f1..447ce47 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1859,15 +1723,7 @@ index 6aaf8f1..447ce47 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1875,7 +1731,7 @@ index 6aaf8f1..447ce47 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1883,7 +1739,7 @@ index 6aaf8f1..447ce47 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1894,12 +1750,7 @@ index 6aaf8f1..447ce47 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/d60fa1d3c21e00bedc0dd94dc2df7e5183c14c48.patch
+++ b/patches/d60fa1d3c21e00bedc0dd94dc2df7e5183c14c48.patch
@@ -962,8 +962,8 @@ index 0991957..010e352 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+use core::ptr;
 +use core::slice;
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1404,16 +1404,16 @@ index 0991957..010e352 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1898,15 +1847,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1899,6 +1848,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1906,7 +1856,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1421,7 +1421,7 @@ index 0991957..010e352 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1933,13 +1876,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -1933,13 +1883,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1435,7 +1435,7 @@ index 0991957..010e352 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1963,14 +1904,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1963,14 +1911,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1452,7 +1452,7 @@ index 0991957..010e352 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -1995,13 +1936,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -1995,13 +1943,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1496,8 +1496,8 @@ index 8df961a..2b08122 100644
 -use mem;
 +use core::fmt;
 +use io::{self, Read, Initializer, Write, ErrorKind};
-+use core::mem;
 +#[cfg(feature="collections")] use io::BufRead;
++use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
  ///

--- a/patches/e1b8898cfb0392f534cc25808a7f6caad36ebbb7.patch
+++ b/patches/e1b8898cfb0392f534cc25808a7f6caad36ebbb7.patch
@@ -15,7 +15,7 @@ index a14c10d..3e78c01 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -311,21 +311,19 @@ diff --git a/cursor.rs b/cursor.rs
 index 873da08..3d39e57 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 873da08..3d39e57 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 873da08..3d39e57 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 873da08..3d39e57 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 873da08..3d39e57 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 873da08..3d39e57 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 873da08..3d39e57 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 873da08..3d39e57 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -214,14 +207,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -214,10 +206,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 873da08..3d39e57 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -236,7 +229,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -236,7 +227,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 873da08..3d39e57 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -247,12 +240,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -247,12 +238,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 873da08..3d39e57 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -264,6 +261,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -282,6 +280,7 @@ fn slice_write_vectored(
+@@ -282,6 +277,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 873da08..3d39e57 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -308,6 +307,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -308,6 +304,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 873da08..3d39e57 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -321,13 +321,13 @@ fn vec_write_vectored(
+@@ -321,7 +318,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -336,12 +336,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -336,7 +332,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -349,12 +350,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -349,7 +345,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -362,13 +364,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -362,8 +358,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 873da08..3d39e57 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index 614b791..e4ce8b5 100644
 --- a/error.rs
@@ -844,7 +804,7 @@ diff --git a/impls.rs b/impls.rs
 index b286e40..7472d9c 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -852,8 +812,8 @@ index b286e40..7472d9c 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -866,14 +826,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -887,7 +840,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -895,12 +848,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -914,7 +862,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -923,14 +871,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -944,7 +885,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -953,12 +894,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -973,7 +909,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -186,7 +194,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
+@@ -186,7 +190,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -981,15 +917,7 @@ index b286e40..7472d9c 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -206,6 +213,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -245,6 +253,7 @@ impl Read for &[u8] {
+@@ -245,6 +248,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -997,7 +925,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -254,7 +263,7 @@ impl Read for &[u8] {
+@@ -254,7 +258,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -1006,7 +934,7 @@ index b286e40..7472d9c 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -268,7 +277,6 @@ impl BufRead for &[u8] {
+@@ -268,7 +272,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1014,15 +942,7 @@ index b286e40..7472d9c 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -279,6 +287,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -307,7 +316,7 @@ impl Write for &mut [u8] {
+@@ -307,7 +310,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1031,14 +951,6 @@ index b286e40..7472d9c 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -315,6 +324,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index e3e2754..400eca6 100644
 --- a/mod.rs
@@ -1072,9 +984,9 @@ index e3e2754..400eca6 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1150,16 +1062,15 @@ index e3e2754..400eca6 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -530,7 +519,7 @@ pub trait Read {
+@@ -530,7 +519,6 @@ pub trait Read {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `read`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          match bufs.iter_mut().find(|b| !b.is_empty()) {
              Some(buf) => self.read(buf),
-@@ -560,7 +549,6 @@ pub trait Read {
+@@ -560,7 +548,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1167,7 +1078,7 @@ index e3e2754..400eca6 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -613,7 +601,7 @@ pub trait Read {
+@@ -613,7 +600,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1176,7 +1087,7 @@ index e3e2754..400eca6 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -656,7 +644,7 @@ pub trait Read {
+@@ -656,7 +643,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1185,7 +1096,7 @@ index e3e2754..400eca6 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -719,7 +707,6 @@ pub trait Read {
+@@ -719,7 +706,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1193,7 +1104,7 @@ index e3e2754..400eca6 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -771,7 +758,6 @@ pub trait Read {
+@@ -771,7 +757,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1201,7 +1112,7 @@ index e3e2754..400eca6 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -808,7 +794,6 @@ pub trait Read {
+@@ -808,7 +793,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1120,7 @@ index e3e2754..400eca6 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -843,7 +828,6 @@ pub trait Read {
+@@ -843,7 +827,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1217,7 +1128,7 @@ index e3e2754..400eca6 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -879,42 +863,77 @@ pub trait Read {
+@@ -879,22 +862,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1227,10 +1138,8 @@ index e3e2754..400eca6 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1242,10 +1151,9 @@ index e3e2754..400eca6 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1269,23 +1177,15 @@ index e3e2754..400eca6 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -907,14 +920,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1298,41 +1198,31 @@ index e3e2754..400eca6 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -924,7 +943,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -924,7 +935,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -937,31 +956,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -937,11 +947,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -954,14 +962,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1345,11 +1235,10 @@ index e3e2754..400eca6 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -972,13 +991,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -972,13 +978,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1363,7 +1252,7 @@ index e3e2754..400eca6 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -992,21 +1009,18 @@ impl Initializer {
+@@ -992,21 +996,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1385,7 +1274,7 @@ index e3e2754..400eca6 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1049,7 +1063,6 @@ impl Initializer {
+@@ -1049,7 +1050,6 @@ impl Initializer {
  ///     Ok(())
  /// }
  /// ```
@@ -1393,7 +1282,7 @@ index e3e2754..400eca6 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1098,7 +1111,6 @@ pub trait Write {
+@@ -1098,7 +1098,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1401,16 +1290,15 @@ index e3e2754..400eca6 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1109,7 +1121,7 @@ pub trait Write {
+@@ -1109,7 +1108,6 @@ pub trait Write {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `write`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          match bufs.iter().find(|b| !b.is_empty()) {
              Some(buf) => self.write(buf),
-@@ -1140,7 +1152,6 @@ pub trait Write {
+@@ -1140,7 +1138,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1418,7 +1306,7 @@ index e3e2754..400eca6 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1173,7 +1184,6 @@ pub trait Write {
+@@ -1173,7 +1170,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1426,7 +1314,7 @@ index e3e2754..400eca6 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1225,7 +1235,6 @@ pub trait Write {
+@@ -1225,7 +1221,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1322,7 @@ index e3e2754..400eca6 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1281,7 +1290,6 @@ pub trait Write {
+@@ -1281,7 +1276,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1442,7 +1330,7 @@ index e3e2754..400eca6 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1311,7 +1319,6 @@ pub trait Write {
+@@ -1311,7 +1305,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1450,7 +1338,7 @@ index e3e2754..400eca6 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1327,7 +1334,6 @@ pub trait Seek {
+@@ -1327,7 +1320,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1458,7 +1346,7 @@ index e3e2754..400eca6 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  }
  
-@@ -1337,29 +1343,26 @@ pub trait Seek {
+@@ -1337,29 +1329,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1492,7 +1380,7 @@ index e3e2754..400eca6 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1439,7 +1442,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1439,7 +1428,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1501,7 +1389,7 @@ index e3e2754..400eca6 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1485,7 +1488,6 @@ pub trait BufRead: Read {
+@@ -1485,7 +1474,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1509,7 +1397,7 @@ index e3e2754..400eca6 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1507,7 +1509,6 @@ pub trait BufRead: Read {
+@@ -1507,7 +1495,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1517,7 +1405,7 @@ index e3e2754..400eca6 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1563,7 +1564,6 @@ pub trait BufRead: Read {
+@@ -1563,7 +1550,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1525,7 +1413,7 @@ index e3e2754..400eca6 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1622,7 +1622,6 @@ pub trait BufRead: Read {
+@@ -1622,7 +1608,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1533,7 +1421,7 @@ index e3e2754..400eca6 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1663,7 +1662,6 @@ pub trait BufRead: Read {
+@@ -1663,7 +1648,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1541,7 +1429,7 @@ index e3e2754..400eca6 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1702,7 +1700,6 @@ pub trait BufRead: Read {
+@@ -1702,7 +1686,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1549,7 +1437,7 @@ index e3e2754..400eca6 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1714,7 +1711,6 @@ pub trait BufRead: Read {
+@@ -1714,7 +1697,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1557,7 +1445,7 @@ index e3e2754..400eca6 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1740,7 +1736,6 @@ impl<T, U> Chain<T, U> {
+@@ -1740,7 +1722,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1565,7 +1453,7 @@ index e3e2754..400eca6 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1763,7 +1758,6 @@ impl<T, U> Chain<T, U> {
+@@ -1763,7 +1744,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1573,7 +1461,7 @@ index e3e2754..400eca6 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1790,13 +1784,11 @@ impl<T, U> Chain<T, U> {
+@@ -1790,13 +1770,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1587,7 +1475,7 @@ index e3e2754..400eca6 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1806,7 +1798,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1806,7 +1784,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1595,15 +1483,7 @@ index e3e2754..400eca6 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1818,6 +1809,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1838,7 +1830,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1838,7 +1815,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1612,7 +1492,7 @@ index e3e2754..400eca6 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1865,7 +1857,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1865,7 +1842,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1620,7 +1500,7 @@ index e3e2754..400eca6 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -1900,7 +1891,6 @@ impl<T> Take<T> {
+@@ -1900,7 +1876,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1628,7 +1508,7 @@ index e3e2754..400eca6 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -1926,7 +1916,6 @@ impl<T> Take<T> {
+@@ -1926,7 +1901,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1636,7 +1516,7 @@ index e3e2754..400eca6 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -1951,7 +1940,6 @@ impl<T> Take<T> {
+@@ -1951,7 +1925,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1644,7 +1524,7 @@ index e3e2754..400eca6 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -1976,7 +1964,6 @@ impl<T> Take<T> {
+@@ -1976,7 +1949,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1652,7 +1532,7 @@ index e3e2754..400eca6 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2005,13 +1992,11 @@ impl<T> Take<T> {
+@@ -2005,13 +1977,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1666,16 +1546,16 @@ index e3e2754..400eca6 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2028,15 +2013,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2029,6 +1999,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2036,7 +2007,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1683,7 +1563,7 @@ index e3e2754..400eca6 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2063,13 +2042,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2063,13 +2034,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1697,7 +1577,7 @@ index e3e2754..400eca6 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2093,14 +2070,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2093,14 +2062,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1714,7 +1594,7 @@ index e3e2754..400eca6 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2125,13 +2102,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2125,13 +2094,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1757,8 +1637,8 @@ index 6aaf8f1..447ce47 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1827,15 +1707,7 @@ index 6aaf8f1..447ce47 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1843,7 +1715,7 @@ index 6aaf8f1..447ce47 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1851,7 +1723,7 @@ index 6aaf8f1..447ce47 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1862,12 +1734,7 @@ index 6aaf8f1..447ce47 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/e3a8f7db479ce6562bfc312f412b65dc4f3c77d5.patch
+++ b/patches/e3a8f7db479ce6562bfc312f412b65dc4f3c77d5.patch
@@ -962,8 +962,8 @@ index b634ea4..1646c3e 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+use core::ptr;
 +use core::slice;
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1404,16 +1404,16 @@ index b634ea4..1646c3e 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1898,15 +1847,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1899,6 +1848,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1906,7 +1856,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1421,7 +1421,7 @@ index b634ea4..1646c3e 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1933,13 +1876,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -1933,13 +1883,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1435,7 +1435,7 @@ index b634ea4..1646c3e 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1963,14 +1904,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1963,14 +1911,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1452,7 +1452,7 @@ index b634ea4..1646c3e 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -1995,13 +1936,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -1995,13 +1943,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1496,8 +1496,8 @@ index 8df961a..2b08122 100644
 -use mem;
 +use core::fmt;
 +use io::{self, Read, Initializer, Write, ErrorKind};
-+use core::mem;
 +#[cfg(feature="collections")] use io::BufRead;
++use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
  ///

--- a/patches/ea505fd60b09bbfb127c874a27abac52d44bfe00.patch
+++ b/patches/ea505fd60b09bbfb127c874a27abac52d44bfe00.patch
@@ -1401,16 +1401,16 @@ index b83f3fb..883fa30 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1906,15 +1855,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1907,6 +1856,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1914,7 +1864,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1418,7 +1418,7 @@ index b83f3fb..883fa30 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1953,13 +1896,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1953,13 +1903,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1432,7 +1432,7 @@ index b83f3fb..883fa30 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1975,14 +1916,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1975,14 +1923,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1449,7 +1449,7 @@ index b83f3fb..883fa30 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2007,13 +1948,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2007,13 +1955,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/ebbecac538137fca1c36ceca91337b5ff4d196b5.patch
+++ b/patches/ebbecac538137fca1c36ceca91337b5ff4d196b5.patch
@@ -962,8 +962,8 @@ index 28a6fbd..2f5ae43 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+use core::ptr;
 +use core::slice;
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1404,16 +1404,16 @@ index 28a6fbd..2f5ae43 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1898,15 +1847,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1899,6 +1848,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1906,7 +1856,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1421,7 +1421,7 @@ index 28a6fbd..2f5ae43 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1933,13 +1876,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -1933,13 +1883,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1435,7 +1435,7 @@ index 28a6fbd..2f5ae43 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1963,14 +1904,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1963,14 +1911,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1452,7 +1452,7 @@ index 28a6fbd..2f5ae43 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -1995,13 +1936,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -1995,13 +1943,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1496,8 +1496,8 @@ index 8df961a..2b08122 100644
 -use mem;
 +use core::fmt;
 +use io::{self, Read, Initializer, Write, ErrorKind};
-+use core::mem;
 +#[cfg(feature="collections")] use io::BufRead;
++use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
  ///

--- a/patches/eca11b99a7d25e4e6573472a16537c1aacb5d5e1.patch
+++ b/patches/eca11b99a7d25e4e6573472a16537c1aacb5d5e1.patch
@@ -1401,16 +1401,16 @@ index e263db2..2176464 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1907,15 +1856,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1908,6 +1857,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1915,7 +1865,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1418,7 +1418,7 @@ index e263db2..2176464 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1954,13 +1897,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1954,13 +1904,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1432,7 +1432,7 @@ index e263db2..2176464 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1976,14 +1917,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1976,14 +1924,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1449,7 +1449,7 @@ index e263db2..2176464 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2008,13 +1949,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2008,13 +1956,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/ee89c088b057affb5bdb96195e107a218b64b1c5.patch
+++ b/patches/ee89c088b057affb5bdb96195e107a218b64b1c5.patch
@@ -1409,16 +1409,16 @@ index dc97701..6ea0b47 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1907,15 +1856,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1908,6 +1857,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1915,7 +1865,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1426,7 +1426,7 @@ index dc97701..6ea0b47 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1954,13 +1897,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1954,13 +1904,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1440,7 +1440,7 @@ index dc97701..6ea0b47 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1976,14 +1917,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1976,14 +1924,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1457,7 +1457,7 @@ index dc97701..6ea0b47 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2008,13 +1949,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2008,13 +1956,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines

--- a/patches/f22dca0a1bef4141e75326caacc3cd59f3d5be8e.patch
+++ b/patches/f22dca0a1bef4141e75326caacc3cd59f3d5be8e.patch
@@ -15,7 +15,7 @@ index a14c10d..3e78c01 100644
 +use core::fmt;
  use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 -use crate::memchr;
-+use io::memchr;
++use crate::io::memchr;
  
  /// The `BufReader` struct adds buffering to any reader.
  ///
@@ -311,21 +311,19 @@ diff --git a/cursor.rs b/cursor.rs
 index 873da08..3d39e57 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
  use crate::io::prelude::*;
  
 -use crate::cmp;
--use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +use core::cmp;
-+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{IoVec, IoVecMut};
+ use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
 -use core::convert::TryInto;
 +#[cfg(feature="collections")] use core::convert::TryInto;
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
  /// [`Seek`] implementation.
-@@ -71,7 +72,6 @@ use core::convert::TryInto;
+@@ -71,7 +71,6 @@ use core::convert::TryInto;
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -333,7 +331,7 @@ index 873da08..3d39e57 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -94,7 +94,6 @@ impl<T> Cursor<T> {
+@@ -94,7 +93,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -341,7 +339,7 @@ index 873da08..3d39e57 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -112,7 +111,6 @@ impl<T> Cursor<T> {
+@@ -112,7 +110,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -349,7 +347,7 @@ index 873da08..3d39e57 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -128,7 +126,6 @@ impl<T> Cursor<T> {
+@@ -128,7 +125,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -357,7 +355,7 @@ index 873da08..3d39e57 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -147,7 +144,6 @@ impl<T> Cursor<T> {
+@@ -147,7 +143,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -365,7 +363,7 @@ index 873da08..3d39e57 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -169,7 +165,6 @@ impl<T> Cursor<T> {
+@@ -169,7 +164,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -373,7 +371,7 @@ index 873da08..3d39e57 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -189,11 +184,9 @@ impl<T> Cursor<T> {
+@@ -189,11 +183,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -385,7 +383,7 @@ index 873da08..3d39e57 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -214,14 +207,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -214,10 +206,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -397,12 +395,7 @@ index 873da08..3d39e57 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -236,7 +229,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -236,7 +227,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -411,7 +404,7 @@ index 873da08..3d39e57 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -247,12 +240,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -247,12 +238,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -431,15 +424,7 @@ index 873da08..3d39e57 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -264,6 +261,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -282,6 +280,7 @@ fn slice_write_vectored(
+@@ -282,6 +277,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -447,7 +432,7 @@ index 873da08..3d39e57 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -308,6 +307,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -308,6 +304,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -455,7 +440,7 @@ index 873da08..3d39e57 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -321,13 +321,13 @@ fn vec_write_vectored(
+@@ -321,7 +318,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -463,14 +448,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -336,12 +336,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -336,7 +332,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -479,13 +457,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -349,12 +350,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -349,7 +345,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -494,13 +466,7 @@ index 873da08..3d39e57 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -362,13 +364,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -362,8 +358,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -511,12 +477,6 @@ index 873da08..3d39e57 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index fdc5625..e4ce8b5 100644
 --- a/error.rs
@@ -836,7 +796,7 @@ diff --git a/impls.rs b/impls.rs
 index b286e40..7472d9c 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use crate::cmp;
 -use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -844,8 +804,8 @@ index b286e40..7472d9c 100644
 -use crate::mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVecMut, IoVec};
++use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -858,14 +818,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -879,7 +832,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -887,12 +840,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -906,7 +854,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -915,14 +863,7 @@ index b286e40..7472d9c 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -936,7 +877,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -945,12 +886,7 @@ index b286e40..7472d9c 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -965,7 +901,7 @@ index b286e40..7472d9c 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -186,7 +194,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
+@@ -186,7 +190,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -973,15 +909,7 @@ index b286e40..7472d9c 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -206,6 +213,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -245,6 +253,7 @@ impl Read for &[u8] {
+@@ -245,6 +248,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -989,7 +917,7 @@ index b286e40..7472d9c 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -254,7 +263,7 @@ impl Read for &[u8] {
+@@ -254,7 +258,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -998,7 +926,7 @@ index b286e40..7472d9c 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -268,7 +277,6 @@ impl BufRead for &[u8] {
+@@ -268,7 +272,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1006,15 +934,7 @@ index b286e40..7472d9c 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -279,6 +287,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -307,7 +316,7 @@ impl Write for &mut [u8] {
+@@ -307,7 +310,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1023,14 +943,6 @@ index b286e40..7472d9c 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -315,6 +324,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index e3e2754..400eca6 100644
 --- a/mod.rs
@@ -1064,9 +976,9 @@ index e3e2754..400eca6 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1142,16 +1054,15 @@ index e3e2754..400eca6 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -530,7 +519,7 @@ pub trait Read {
+@@ -530,7 +519,6 @@ pub trait Read {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `read`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          match bufs.iter_mut().find(|b| !b.is_empty()) {
              Some(buf) => self.read(buf),
-@@ -560,7 +549,6 @@ pub trait Read {
+@@ -560,7 +548,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1159,7 +1070,7 @@ index e3e2754..400eca6 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -613,7 +601,7 @@ pub trait Read {
+@@ -613,7 +600,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1168,7 +1079,7 @@ index e3e2754..400eca6 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -656,7 +644,7 @@ pub trait Read {
+@@ -656,7 +643,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1177,7 +1088,7 @@ index e3e2754..400eca6 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -719,7 +707,6 @@ pub trait Read {
+@@ -719,7 +706,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1185,7 +1096,7 @@ index e3e2754..400eca6 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -771,7 +758,6 @@ pub trait Read {
+@@ -771,7 +757,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1193,7 +1104,7 @@ index e3e2754..400eca6 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -808,7 +794,6 @@ pub trait Read {
+@@ -808,7 +793,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1201,7 +1112,7 @@ index e3e2754..400eca6 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -843,7 +828,6 @@ pub trait Read {
+@@ -843,7 +827,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1209,7 +1120,7 @@ index e3e2754..400eca6 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -879,42 +863,77 @@ pub trait Read {
+@@ -879,22 +862,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1219,10 +1130,8 @@ index e3e2754..400eca6 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1234,10 +1143,9 @@ index e3e2754..400eca6 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1261,23 +1169,15 @@ index e3e2754..400eca6 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -907,14 +920,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1290,41 +1190,31 @@ index e3e2754..400eca6 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -924,7 +943,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -924,7 +935,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -937,31 +956,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -937,11 +947,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -954,14 +962,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1337,11 +1227,10 @@ index e3e2754..400eca6 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -972,13 +991,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -972,13 +978,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1355,7 +1244,7 @@ index e3e2754..400eca6 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -992,21 +1009,18 @@ impl Initializer {
+@@ -992,21 +996,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1377,7 +1266,7 @@ index e3e2754..400eca6 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1049,7 +1063,6 @@ impl Initializer {
+@@ -1049,7 +1050,6 @@ impl Initializer {
  ///     Ok(())
  /// }
  /// ```
@@ -1385,7 +1274,7 @@ index e3e2754..400eca6 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1098,7 +1111,6 @@ pub trait Write {
+@@ -1098,7 +1098,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1393,16 +1282,15 @@ index e3e2754..400eca6 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1109,7 +1121,7 @@ pub trait Write {
+@@ -1109,7 +1108,6 @@ pub trait Write {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `write`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          match bufs.iter().find(|b| !b.is_empty()) {
              Some(buf) => self.write(buf),
-@@ -1140,7 +1152,6 @@ pub trait Write {
+@@ -1140,7 +1138,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1410,7 +1298,7 @@ index e3e2754..400eca6 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1173,7 +1184,6 @@ pub trait Write {
+@@ -1173,7 +1170,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1418,7 +1306,7 @@ index e3e2754..400eca6 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1225,7 +1235,6 @@ pub trait Write {
+@@ -1225,7 +1221,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1426,7 +1314,7 @@ index e3e2754..400eca6 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1281,7 +1290,6 @@ pub trait Write {
+@@ -1281,7 +1276,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1434,7 +1322,7 @@ index e3e2754..400eca6 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1311,7 +1319,6 @@ pub trait Write {
+@@ -1311,7 +1305,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1442,7 +1330,7 @@ index e3e2754..400eca6 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1327,7 +1334,6 @@ pub trait Seek {
+@@ -1327,7 +1320,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1450,7 +1338,7 @@ index e3e2754..400eca6 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  }
  
-@@ -1337,29 +1343,26 @@ pub trait Seek {
+@@ -1337,29 +1329,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1484,7 +1372,7 @@ index e3e2754..400eca6 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1439,7 +1442,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1439,7 +1428,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1493,7 +1381,7 @@ index e3e2754..400eca6 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1485,7 +1488,6 @@ pub trait BufRead: Read {
+@@ -1485,7 +1474,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1501,7 +1389,7 @@ index e3e2754..400eca6 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1507,7 +1509,6 @@ pub trait BufRead: Read {
+@@ -1507,7 +1495,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1509,7 +1397,7 @@ index e3e2754..400eca6 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1563,7 +1564,6 @@ pub trait BufRead: Read {
+@@ -1563,7 +1550,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1517,7 +1405,7 @@ index e3e2754..400eca6 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1622,7 +1622,6 @@ pub trait BufRead: Read {
+@@ -1622,7 +1608,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1525,7 +1413,7 @@ index e3e2754..400eca6 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1663,7 +1662,6 @@ pub trait BufRead: Read {
+@@ -1663,7 +1648,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1533,7 +1421,7 @@ index e3e2754..400eca6 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1702,7 +1700,6 @@ pub trait BufRead: Read {
+@@ -1702,7 +1686,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1541,7 +1429,7 @@ index e3e2754..400eca6 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1714,7 +1711,6 @@ pub trait BufRead: Read {
+@@ -1714,7 +1697,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1549,7 +1437,7 @@ index e3e2754..400eca6 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1740,7 +1736,6 @@ impl<T, U> Chain<T, U> {
+@@ -1740,7 +1722,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1557,7 +1445,7 @@ index e3e2754..400eca6 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1763,7 +1758,6 @@ impl<T, U> Chain<T, U> {
+@@ -1763,7 +1744,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1565,7 +1453,7 @@ index e3e2754..400eca6 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1790,13 +1784,11 @@ impl<T, U> Chain<T, U> {
+@@ -1790,13 +1770,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1579,7 +1467,7 @@ index e3e2754..400eca6 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1806,7 +1798,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1806,7 +1784,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1587,15 +1475,7 @@ index e3e2754..400eca6 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1818,6 +1809,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1838,7 +1830,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1838,7 +1815,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1604,7 +1484,7 @@ index e3e2754..400eca6 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1865,7 +1857,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1865,7 +1842,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1612,7 +1492,7 @@ index e3e2754..400eca6 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -1900,7 +1891,6 @@ impl<T> Take<T> {
+@@ -1900,7 +1876,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1620,7 +1500,7 @@ index e3e2754..400eca6 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -1926,7 +1916,6 @@ impl<T> Take<T> {
+@@ -1926,7 +1901,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1628,7 +1508,7 @@ index e3e2754..400eca6 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -1951,7 +1940,6 @@ impl<T> Take<T> {
+@@ -1951,7 +1925,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1636,7 +1516,7 @@ index e3e2754..400eca6 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -1976,7 +1964,6 @@ impl<T> Take<T> {
+@@ -1976,7 +1949,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1644,7 +1524,7 @@ index e3e2754..400eca6 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2005,13 +1992,11 @@ impl<T> Take<T> {
+@@ -2005,13 +1977,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1658,16 +1538,16 @@ index e3e2754..400eca6 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2028,15 +2013,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2029,6 +1999,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2036,7 +2007,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1675,7 +1555,7 @@ index e3e2754..400eca6 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2063,13 +2042,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2063,13 +2034,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1689,7 +1569,7 @@ index e3e2754..400eca6 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2093,14 +2070,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2093,14 +2062,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1706,7 +1586,7 @@ index e3e2754..400eca6 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2125,13 +2102,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2125,13 +2094,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1749,8 +1629,8 @@ index 6aaf8f1..447ce47 100644
 -use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use crate::mem;
 +use core::fmt;
-+use crate::io::{self, Read, Initializer, Write, ErrorKind};
-+#[cfg(feature="collections")] use crate::io::{BufRead, IoVec, IoVecMut};
++use crate::io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use crate::io::BufRead;
 +use core::mem;
  
  /// Copies the entire contents of a reader into a writer.
@@ -1819,15 +1699,7 @@ index 6aaf8f1..447ce47 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1835,7 +1707,7 @@ index 6aaf8f1..447ce47 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1843,7 +1715,7 @@ index 6aaf8f1..447ce47 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1854,12 +1726,7 @@ index 6aaf8f1..447ce47 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/fb162e69449b423c5aed0d9c39f6c046fa300c30.patch
+++ b/patches/fb162e69449b423c5aed0d9c39f6c046fa300c30.patch
@@ -311,20 +311,17 @@ diff --git a/cursor.rs b/cursor.rs
 index 577a115..8813aba 100644
 --- a/cursor.rs
 +++ b/cursor.rs
-@@ -1,8 +1,9 @@
+@@ -1,7 +1,7 @@
  use io::prelude::*;
  
 -use core::convert::TryInto;
 -use cmp;
--use io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 +#[cfg(feature="collections")] use core::convert::TryInto;
 +use core::cmp;
-+use io::{self, Initializer, SeekFrom, Error, ErrorKind};
-+#[cfg(feature="collections")] use io::{IoVec, IoVecMut};
+ use io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  
  /// A `Cursor` wraps an in-memory buffer and provides it with a
- /// [`Seek`] implementation.
-@@ -70,7 +71,6 @@ use io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
+@@ -70,7 +70,6 @@ use io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
  ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
  /// }
  /// ```
@@ -332,7 +329,7 @@ index 577a115..8813aba 100644
  #[derive(Clone, Debug)]
  pub struct Cursor<T> {
      inner: T,
-@@ -93,7 +93,6 @@ impl<T> Cursor<T> {
+@@ -93,7 +92,6 @@ impl<T> Cursor<T> {
      /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
      /// # force_inference(&buff);
      /// ```
@@ -340,7 +337,7 @@ index 577a115..8813aba 100644
      pub fn new(inner: T) -> Cursor<T> {
          Cursor { pos: 0, inner: inner }
      }
-@@ -111,7 +110,6 @@ impl<T> Cursor<T> {
+@@ -111,7 +109,6 @@ impl<T> Cursor<T> {
      ///
      /// let vec = buff.into_inner();
      /// ```
@@ -348,7 +345,7 @@ index 577a115..8813aba 100644
      pub fn into_inner(self) -> T { self.inner }
  
      /// Gets a reference to the underlying value in this cursor.
-@@ -127,7 +125,6 @@ impl<T> Cursor<T> {
+@@ -127,7 +124,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_ref();
      /// ```
@@ -356,7 +353,7 @@ index 577a115..8813aba 100644
      pub fn get_ref(&self) -> &T { &self.inner }
  
      /// Gets a mutable reference to the underlying value in this cursor.
-@@ -146,7 +143,6 @@ impl<T> Cursor<T> {
+@@ -146,7 +142,6 @@ impl<T> Cursor<T> {
      ///
      /// let reference = buff.get_mut();
      /// ```
@@ -364,7 +361,7 @@ index 577a115..8813aba 100644
      pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
  
      /// Returns the current position of this cursor.
-@@ -168,7 +164,6 @@ impl<T> Cursor<T> {
+@@ -168,7 +163,6 @@ impl<T> Cursor<T> {
      /// buff.seek(SeekFrom::Current(-1)).unwrap();
      /// assert_eq!(buff.position(), 1);
      /// ```
@@ -372,7 +369,7 @@ index 577a115..8813aba 100644
      pub fn position(&self) -> u64 { self.pos }
  
      /// Sets the position of this cursor.
-@@ -188,11 +183,9 @@ impl<T> Cursor<T> {
+@@ -188,11 +182,9 @@ impl<T> Cursor<T> {
      /// buff.set_position(4);
      /// assert_eq!(buff.position(), 4);
      /// ```
@@ -384,7 +381,7 @@ index 577a115..8813aba 100644
  impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
          let (base_pos, offset) = match style {
-@@ -213,14 +206,14 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
+@@ -213,10 +205,9 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -396,12 +393,7 @@ index 577a115..8813aba 100644
          self.pos += n as u64;
          Ok(n)
      }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-         for buf in bufs {
-@@ -235,7 +228,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -235,7 +226,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
  
      fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
          let n = buf.len();
@@ -410,7 +402,7 @@ index 577a115..8813aba 100644
          self.pos += n as u64;
          Ok(())
      }
-@@ -246,12 +239,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
+@@ -246,12 +237,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
      }
  }
  
@@ -430,15 +422,7 @@ index 577a115..8813aba 100644
      fn consume(&mut self, amt: usize) { self.pos += amt as u64; }
  }
  
-@@ -263,6 +260,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
-     Ok(amt)
- }
- 
-+#[cfg(feature="collections")]
- fn slice_write_vectored(
-     pos_mut: &mut u64,
-     slice: &mut [u8],
-@@ -281,6 +279,7 @@ fn slice_write_vectored(
+@@ -281,6 +276,7 @@ fn slice_write_vectored(
  }
  
  // Resizing write implementation
@@ -446,7 +430,7 @@ index 577a115..8813aba 100644
  fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
      let pos: usize = (*pos_mut).try_into().map_err(|_| {
          Error::new(ErrorKind::InvalidInput,
-@@ -307,6 +306,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
+@@ -307,6 +303,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
      Ok(buf.len())
  }
  
@@ -454,7 +438,7 @@ index 577a115..8813aba 100644
  fn vec_write_vectored(
      pos_mut: &mut u64,
      vec: &mut Vec<u8>,
-@@ -320,13 +320,13 @@ fn vec_write_vectored(
+@@ -320,7 +317,6 @@ fn vec_write_vectored(
      Ok(nwritten)
  }
  
@@ -462,14 +446,7 @@ index 577a115..8813aba 100644
  impl Write for Cursor<&mut [u8]> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-         slice_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, self.inner, bufs)
-@@ -335,12 +335,13 @@ impl Write for Cursor<&mut [u8]> {
+@@ -335,7 +331,7 @@ impl Write for Cursor<&mut [u8]> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -478,13 +455,7 @@ index 577a115..8813aba 100644
  impl Write for Cursor<&mut Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, self.inner, bufs)
-     }
-@@ -348,12 +349,13 @@ impl Write for Cursor<&mut Vec<u8>> {
+@@ -348,7 +344,7 @@ impl Write for Cursor<&mut Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -493,13 +464,7 @@ index 577a115..8813aba 100644
  impl Write for Cursor<Vec<u8>> {
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          vec_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
-     }
-@@ -361,13 +363,14 @@ impl Write for Cursor<Vec<u8>> {
+@@ -361,8 +357,8 @@ impl Write for Cursor<Vec<u8>> {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  
@@ -510,12 +475,6 @@ index 577a115..8813aba 100644
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
          slice_write(&mut self.pos, &mut self.inner, buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
 diff --git a/error.rs b/error.rs
 index e9b4f60..31c0ff1 100644
 --- a/error.rs
@@ -835,7 +794,7 @@ diff --git a/impls.rs b/impls.rs
 index aa8db17..aaf1b00 100644
 --- a/impls.rs
 +++ b/impls.rs
-@@ -1,19 +1,22 @@
+@@ -1,13 +1,15 @@
 -use cmp;
 -use io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
 -         IoVec};
@@ -843,8 +802,8 @@ index aa8db17..aaf1b00 100644
 -use mem;
 +#[cfg(feature="alloc")] use alloc::boxed::Box;
 +use core::cmp;
-+use io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind};
-+#[cfg(feature="collections")] use io::{BufRead, IoVecMut, IoVec};
++use io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoVecMut, IoVec};
++#[cfg(feature="collections")] use io::BufRead;
 +use core::fmt;
 +use core::mem;
 +#[cfg(feature="collections")] use collections::string::String;
@@ -857,14 +816,7 @@ index aa8db17..aaf1b00 100644
  impl<R: Read + ?Sized> Read for &mut R {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -24,11 +27,13 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -24,11 +26,13 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).initializer()
      }
  
@@ -878,7 +830,7 @@ index aa8db17..aaf1b00 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -39,11 +44,11 @@ impl<R: Read + ?Sized> Read for &mut R {
+@@ -39,7 +43,6 @@ impl<R: Read + ?Sized> Read for &mut R {
          (**self).read_exact(buf)
      }
  }
@@ -886,12 +838,7 @@ index aa8db17..aaf1b00 100644
  impl<W: Write + ?Sized> Write for &mut W {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -62,12 +67,11 @@ impl<W: Write + ?Sized> Write for &mut W {
+@@ -62,12 +65,11 @@ impl<W: Write + ?Sized> Write for &mut W {
          (**self).write_fmt(fmt)
      }
  }
@@ -905,7 +852,7 @@ index aa8db17..aaf1b00 100644
  impl<B: BufRead + ?Sized> BufRead for &mut B {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -86,13 +90,14 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
+@@ -86,7 +88,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
      }
  }
  
@@ -914,14 +861,7 @@ index aa8db17..aaf1b00 100644
  impl<R: Read + ?Sized> Read for Box<R> {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-         (**self).read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         (**self).read_vectored(bufs)
-@@ -103,11 +108,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -103,11 +105,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).initializer()
      }
  
@@ -935,7 +875,7 @@ index aa8db17..aaf1b00 100644
      #[inline]
      fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
          (**self).read_to_string(buf)
-@@ -118,11 +125,12 @@ impl<R: Read + ?Sized> Read for Box<R> {
+@@ -118,7 +122,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
          (**self).read_exact(buf)
      }
  }
@@ -944,12 +884,7 @@ index aa8db17..aaf1b00 100644
  impl<W: Write + ?Sized> Write for Box<W> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         (**self).write_vectored(bufs)
-@@ -141,12 +149,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
+@@ -141,12 +145,12 @@ impl<W: Write + ?Sized> Write for Box<W> {
          (**self).write_fmt(fmt)
      }
  }
@@ -964,7 +899,7 @@ index aa8db17..aaf1b00 100644
  impl<B: BufRead + ?Sized> BufRead for Box<B> {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-@@ -172,7 +180,6 @@ impl<B: BufRead + ?Sized> BufRead for Box<B> {
+@@ -172,7 +176,6 @@ impl<B: BufRead + ?Sized> BufRead for Box<B> {
  ///
  /// Note that reading updates the slice to point to the yet unread part.
  /// The slice will be empty when EOF is reached.
@@ -972,15 +907,7 @@ index aa8db17..aaf1b00 100644
  impl Read for &[u8] {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -192,6 +199,7 @@ impl Read for &[u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nread = 0;
-@@ -231,6 +239,7 @@ impl Read for &[u8] {
+@@ -231,6 +234,7 @@ impl Read for &[u8] {
          Ok(())
      }
  
@@ -988,7 +915,7 @@ index aa8db17..aaf1b00 100644
      #[inline]
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
          buf.extend_from_slice(*self);
-@@ -240,7 +249,7 @@ impl Read for &[u8] {
+@@ -240,7 +244,7 @@ impl Read for &[u8] {
      }
  }
  
@@ -997,7 +924,7 @@ index aa8db17..aaf1b00 100644
  impl BufRead for &[u8] {
      #[inline]
      fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
-@@ -254,7 +263,6 @@ impl BufRead for &[u8] {
+@@ -254,7 +258,6 @@ impl BufRead for &[u8] {
  ///
  /// Note that writing updates the slice to point to the yet unwritten part.
  /// The slice will be empty when it has been completely overwritten.
@@ -1005,15 +932,7 @@ index aa8db17..aaf1b00 100644
  impl Write for &mut [u8] {
      #[inline]
      fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-@@ -265,6 +273,7 @@ impl Write for &mut [u8] {
-         Ok(amt)
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -293,7 +302,7 @@ impl Write for &mut [u8] {
+@@ -293,7 +296,7 @@ impl Write for &mut [u8] {
  
  /// Write is implemented for `Vec<u8>` by appending to the vector.
  /// The vector will grow as needed.
@@ -1022,14 +941,6 @@ index aa8db17..aaf1b00 100644
  impl Write for Vec<u8> {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-@@ -301,6 +310,7 @@ impl Write for Vec<u8> {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let len = bufs.iter().map(|b| b.len()).sum();
 diff --git a/mod.rs b/mod.rs
 index 12b158e..90064c4 100644
 --- a/mod.rs
@@ -1063,9 +974,9 @@ index 12b158e..90064c4 100644
 +mod memchr;
 +#[cfg(all(feature="collections",core_memchr))]
 +use core::slice::memchr;
-+#[cfg(feature="collections")] use core::ops::{Deref, DerefMut};
-+use core::ptr;
 +use core::slice;
++use core::ops::{Deref, DerefMut};
++use core::ptr;
 +
 +#[cfg(feature="collections")] pub use self::buffered::{BufReader, BufWriter, LineWriter};
 +#[cfg(feature="collections")] pub use self::buffered::IntoInnerError;
@@ -1141,16 +1052,15 @@ index 12b158e..90064c4 100644
      fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
  
      /// Like `read`, except that it reads into a slice of buffers.
-@@ -530,7 +519,7 @@ pub trait Read {
+@@ -530,7 +519,6 @@ pub trait Read {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `read`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
          match bufs.iter_mut().find(|b| !b.is_empty()) {
              Some(buf) => self.read(buf),
-@@ -560,7 +549,6 @@ pub trait Read {
+@@ -560,7 +548,6 @@ pub trait Read {
      ///
      /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
      /// [`Initializer`]: ../../std/io/struct.Initializer.html
@@ -1158,7 +1068,7 @@ index 12b158e..90064c4 100644
      #[inline]
      unsafe fn initializer(&self) -> Initializer {
          Initializer::zeroing()
-@@ -613,7 +601,7 @@ pub trait Read {
+@@ -613,7 +600,7 @@ pub trait Read {
      /// file.)
      ///
      /// [`std::fs::read`]: ../fs/fn.read.html
@@ -1167,7 +1077,7 @@ index 12b158e..90064c4 100644
      fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
          read_to_end(self, buf)
      }
-@@ -656,7 +644,7 @@ pub trait Read {
+@@ -656,7 +643,7 @@ pub trait Read {
      /// reading from a file.)
      ///
      /// [`std::fs::read_to_string`]: ../fs/fn.read_to_string.html
@@ -1176,7 +1086,7 @@ index 12b158e..90064c4 100644
      fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we do *not* call `.read_to_end()` here. We are passing
          // `&mut Vec<u8>` (the raw contents of `buf`) into the `read_to_end`
-@@ -719,7 +707,6 @@ pub trait Read {
+@@ -719,7 +706,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1184,7 +1094,7 @@ index 12b158e..90064c4 100644
      fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.read(buf) {
-@@ -771,7 +758,6 @@ pub trait Read {
+@@ -771,7 +757,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1192,7 +1102,7 @@ index 12b158e..90064c4 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  
      /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
-@@ -808,7 +794,6 @@ pub trait Read {
+@@ -808,7 +793,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1200,7 +1110,7 @@ index 12b158e..90064c4 100644
      fn bytes(self) -> Bytes<Self> where Self: Sized {
          Bytes { inner: self }
      }
-@@ -843,7 +828,6 @@ pub trait Read {
+@@ -843,7 +827,6 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1208,7 +1118,7 @@ index 12b158e..90064c4 100644
      fn chain<R: Read>(self, next: R) -> Chain<Self, R> where Self: Sized {
          Chain { first: self, second: next, done_first: false }
      }
-@@ -879,42 +863,77 @@ pub trait Read {
+@@ -879,22 +862,52 @@ pub trait Read {
      ///     Ok(())
      /// }
      /// ```
@@ -1218,10 +1128,8 @@ index 12b158e..90064c4 100644
      }
  }
  
-+#[cfg(feature="collections")]
 +pub struct IoVecBuffer<'a>(&'a [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a [u8]) -> IoVecBuffer<'a> {
@@ -1233,10 +1141,9 @@ index 12b158e..90064c4 100644
 +        self.0
 +    }
 +}
-+#[cfg(feature="collections")]
++
 +pub struct IoVecMutBuffer<'a>(&'a mut [u8]);
 +
-+#[cfg(feature="collections")]
 +impl<'a> IoVecMutBuffer<'a> {
 +    #[inline]
 +    pub fn new(buf: &'a mut [u8]) -> IoVecMutBuffer<'a> {
@@ -1260,23 +1167,15 @@ index 12b158e..90064c4 100644
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 +pub struct IoVecMut<'a>(IoVecMutBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVecMut<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVecMut<'a> {
-     /// Creates a new `IoVecMut` wrapping a byte slice.
-     ///
+@@ -907,14 +920,12 @@ impl<'a> IoVecMut<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1289,41 +1188,31 @@ index 12b158e..90064c4 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVecMut<'a> {
      type Target = [u8];
  
-@@ -924,7 +943,7 @@ impl<'a> Deref for IoVecMut<'a> {
+@@ -924,7 +935,6 @@ impl<'a> Deref for IoVecMut<'a> {
      }
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> DerefMut for IoVecMut<'a> {
      #[inline]
      fn deref_mut(&mut self) -> &mut [u8] {
-@@ -937,31 +956,31 @@ impl<'a> DerefMut for IoVecMut<'a> {
+@@ -937,11 +947,9 @@ impl<'a> DerefMut for IoVecMut<'a> {
  /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
  /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
  /// Windows.
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  #[repr(transparent)]
 -pub struct IoVec<'a>(sys::io::IoVec<'a>);
 +pub struct IoVec<'a>(IoVecBuffer<'a>);
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> fmt::Debug for IoVec<'a> {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          fmt::Debug::fmt(self.0.as_slice(), fmt)
-     }
- }
- 
-+#[cfg(feature="collections")]
- impl<'a> IoVec<'a> {
-     /// Creates a new `IoVec` wrapping a byte slice.
-     ///
+@@ -954,14 +962,12 @@ impl<'a> IoVec<'a> {
      /// # Panics
      ///
      /// Panics on Windows if the slice is larger than 4GB.
@@ -1336,11 +1225,10 @@ index 12b158e..90064c4 100644
  }
  
 -#[unstable(feature = "iovec", issue = "58452")]
-+#[cfg(feature="collections")]
  impl<'a> Deref for IoVec<'a> {
      type Target = [u8];
  
-@@ -972,13 +991,11 @@ impl<'a> Deref for IoVec<'a> {
+@@ -972,13 +978,11 @@ impl<'a> Deref for IoVec<'a> {
  }
  
  /// A type used to conditionally initialize buffers passed to `Read` methods.
@@ -1354,7 +1242,7 @@ index 12b158e..90064c4 100644
      #[inline]
      pub fn zeroing() -> Initializer {
          Initializer(true)
-@@ -992,21 +1009,18 @@ impl Initializer {
+@@ -992,21 +996,18 @@ impl Initializer {
      /// read from buffers passed to `Read` methods, and that the return value of
      /// the method accurately reflects the number of bytes that have been
      /// written to the head of the buffer.
@@ -1376,7 +1264,7 @@ index 12b158e..90064c4 100644
      #[inline]
      pub fn initialize(&self, buf: &mut [u8]) {
          if self.should_initialize() {
-@@ -1049,7 +1063,6 @@ impl Initializer {
+@@ -1049,7 +1050,6 @@ impl Initializer {
  ///     Ok(())
  /// }
  /// ```
@@ -1384,7 +1272,7 @@ index 12b158e..90064c4 100644
  #[doc(spotlight)]
  pub trait Write {
      /// Write a buffer into this writer, returning how many bytes were written.
-@@ -1098,7 +1111,6 @@ pub trait Write {
+@@ -1098,7 +1098,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1392,16 +1280,15 @@ index 12b158e..90064c4 100644
      fn write(&mut self, buf: &[u8]) -> Result<usize>;
  
      /// Like `write`, except that it writes from a slice of buffers.
-@@ -1109,7 +1121,7 @@ pub trait Write {
+@@ -1109,7 +1108,6 @@ pub trait Write {
      ///
      /// The default implementation simply passes the first nonempty buffer to
      /// `write`.
 -    #[unstable(feature = "iovec", issue = "58452")]
-+    #[cfg(feature="collections")]
      fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
          match bufs.iter().find(|b| !b.is_empty()) {
              Some(buf) => self.write(buf),
-@@ -1140,7 +1152,6 @@ pub trait Write {
+@@ -1140,7 +1138,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1409,7 +1296,7 @@ index 12b158e..90064c4 100644
      fn flush(&mut self) -> Result<()>;
  
      /// Attempts to write an entire buffer into this writer.
-@@ -1173,7 +1184,6 @@ pub trait Write {
+@@ -1173,7 +1170,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1417,7 +1304,7 @@ index 12b158e..90064c4 100644
      fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
          while !buf.is_empty() {
              match self.write(buf) {
-@@ -1225,7 +1235,6 @@ pub trait Write {
+@@ -1225,7 +1221,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1425,7 +1312,7 @@ index 12b158e..90064c4 100644
      fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<()> {
          // Create a shim which translates a Write to a fmt::Write and saves
          // off I/O errors. instead of discarding them
-@@ -1281,7 +1290,6 @@ pub trait Write {
+@@ -1281,7 +1276,6 @@ pub trait Write {
      ///     Ok(())
      /// }
      /// ```
@@ -1433,7 +1320,7 @@ index 12b158e..90064c4 100644
      fn by_ref(&mut self) -> &mut Self where Self: Sized { self }
  }
  
-@@ -1311,7 +1319,6 @@ pub trait Write {
+@@ -1311,7 +1305,6 @@ pub trait Write {
  ///     Ok(())
  /// }
  /// ```
@@ -1441,7 +1328,7 @@ index 12b158e..90064c4 100644
  pub trait Seek {
      /// Seek to an offset, in bytes, in a stream.
      ///
-@@ -1327,7 +1334,6 @@ pub trait Seek {
+@@ -1327,7 +1320,6 @@ pub trait Seek {
      /// Seeking to a negative offset is considered an error.
      ///
      /// [`SeekFrom::Start`]: enum.SeekFrom.html#variant.Start
@@ -1449,7 +1336,7 @@ index 12b158e..90064c4 100644
      fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
  }
  
-@@ -1337,29 +1343,26 @@ pub trait Seek {
+@@ -1337,29 +1329,26 @@ pub trait Seek {
  ///
  /// [`Seek`]: trait.Seek.html
  #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -1483,7 +1370,7 @@ index 12b158e..90064c4 100644
  fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
                                     -> Result<usize> {
      let mut read = 0;
-@@ -1439,7 +1442,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
+@@ -1439,7 +1428,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
  /// }
  /// ```
  ///
@@ -1492,7 +1379,7 @@ index 12b158e..90064c4 100644
  pub trait BufRead: Read {
      /// Returns the contents of the internal buffer, filling it with more data
      /// from the inner reader if it is empty.
-@@ -1485,7 +1488,6 @@ pub trait BufRead: Read {
+@@ -1485,7 +1474,6 @@ pub trait BufRead: Read {
      /// // ensure the bytes we worked with aren't returned again later
      /// stdin.consume(length);
      /// ```
@@ -1500,7 +1387,7 @@ index 12b158e..90064c4 100644
      fn fill_buf(&mut self) -> Result<&[u8]>;
  
      /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-@@ -1507,7 +1509,6 @@ pub trait BufRead: Read {
+@@ -1507,7 +1495,6 @@ pub trait BufRead: Read {
      /// that method's example includes an example of `consume()`.
      ///
      /// [`fill_buf`]: #tymethod.fill_buf
@@ -1508,7 +1395,7 @@ index 12b158e..90064c4 100644
      fn consume(&mut self, amt: usize);
  
      /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
-@@ -1563,7 +1564,6 @@ pub trait BufRead: Read {
+@@ -1563,7 +1550,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, b"");
      /// ```
@@ -1516,7 +1403,7 @@ index 12b158e..90064c4 100644
      fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
          read_until(self, byte, buf)
      }
-@@ -1622,7 +1622,6 @@ pub trait BufRead: Read {
+@@ -1622,7 +1608,6 @@ pub trait BufRead: Read {
      /// assert_eq!(num_bytes, 0);
      /// assert_eq!(buf, "");
      /// ```
@@ -1524,7 +1411,7 @@ index 12b158e..90064c4 100644
      fn read_line(&mut self, buf: &mut String) -> Result<usize> {
          // Note that we are not calling the `.read_until` method here, but
          // rather our hardcoded implementation. For more details as to why, see
-@@ -1663,7 +1662,6 @@ pub trait BufRead: Read {
+@@ -1663,7 +1648,6 @@ pub trait BufRead: Read {
      /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
      /// assert_eq!(split_iter.next(), None);
      /// ```
@@ -1532,7 +1419,7 @@ index 12b158e..90064c4 100644
      fn split(self, byte: u8) -> Split<Self> where Self: Sized {
          Split { buf: self, delim: byte }
      }
-@@ -1702,7 +1700,6 @@ pub trait BufRead: Read {
+@@ -1702,7 +1686,6 @@ pub trait BufRead: Read {
      /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
      ///
      /// [`BufRead::read_line`]: trait.BufRead.html#method.read_line
@@ -1540,7 +1427,7 @@ index 12b158e..90064c4 100644
      fn lines(self) -> Lines<Self> where Self: Sized {
          Lines { buf: self }
      }
-@@ -1714,7 +1711,6 @@ pub trait BufRead: Read {
+@@ -1714,7 +1697,6 @@ pub trait BufRead: Read {
  /// Please see the documentation of [`chain`] for more details.
  ///
  /// [`chain`]: trait.Read.html#method.chain
@@ -1548,7 +1435,7 @@ index 12b158e..90064c4 100644
  pub struct Chain<T, U> {
      first: T,
      second: U,
-@@ -1740,7 +1736,6 @@ impl<T, U> Chain<T, U> {
+@@ -1740,7 +1722,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1556,7 +1443,7 @@ index 12b158e..90064c4 100644
      pub fn into_inner(self) -> (T, U) {
          (self.first, self.second)
      }
-@@ -1763,7 +1758,6 @@ impl<T, U> Chain<T, U> {
+@@ -1763,7 +1744,6 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1564,7 +1451,7 @@ index 12b158e..90064c4 100644
      pub fn get_ref(&self) -> (&T, &U) {
          (&self.first, &self.second)
      }
-@@ -1790,13 +1784,11 @@ impl<T, U> Chain<T, U> {
+@@ -1790,13 +1770,11 @@ impl<T, U> Chain<T, U> {
      ///     Ok(())
      /// }
      /// ```
@@ -1578,7 +1465,7 @@ index 12b158e..90064c4 100644
  impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.debug_struct("Chain")
-@@ -1806,7 +1798,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
+@@ -1806,7 +1784,6 @@ impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for Chain<T, U> {
      }
  }
  
@@ -1586,15 +1473,7 @@ index 12b158e..90064c4 100644
  impl<T: Read, U: Read> Read for Chain<T, U> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          if !self.done_first {
-@@ -1818,6 +1809,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
-         self.second.read(buf)
-     }
- 
-+    #[cfg(feature="collections")]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
-         if !self.done_first {
-             match self.first.read_vectored(bufs)? {
-@@ -1838,7 +1830,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
+@@ -1838,7 +1815,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
      }
  }
  
@@ -1603,7 +1482,7 @@ index 12b158e..90064c4 100644
  impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          if !self.done_first {
-@@ -1865,7 +1857,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
+@@ -1865,7 +1842,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
  /// Please see the documentation of [`take`] for more details.
  ///
  /// [`take`]: trait.Read.html#method.take
@@ -1611,7 +1490,7 @@ index 12b158e..90064c4 100644
  #[derive(Debug)]
  pub struct Take<T> {
      inner: T,
-@@ -1900,7 +1891,6 @@ impl<T> Take<T> {
+@@ -1900,7 +1876,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1619,7 +1498,7 @@ index 12b158e..90064c4 100644
      pub fn limit(&self) -> u64 { self.limit }
  
      /// Sets the number of bytes that can be read before this instance will
-@@ -1926,7 +1916,6 @@ impl<T> Take<T> {
+@@ -1926,7 +1901,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1627,7 +1506,7 @@ index 12b158e..90064c4 100644
      pub fn set_limit(&mut self, limit: u64) {
          self.limit = limit;
      }
-@@ -1951,7 +1940,6 @@ impl<T> Take<T> {
+@@ -1951,7 +1925,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1635,7 +1514,7 @@ index 12b158e..90064c4 100644
      pub fn into_inner(self) -> T {
          self.inner
      }
-@@ -1976,7 +1964,6 @@ impl<T> Take<T> {
+@@ -1976,7 +1949,6 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1643,7 +1522,7 @@ index 12b158e..90064c4 100644
      pub fn get_ref(&self) -> &T {
          &self.inner
      }
-@@ -2005,13 +1992,11 @@ impl<T> Take<T> {
+@@ -2005,13 +1977,11 @@ impl<T> Take<T> {
      ///     Ok(())
      /// }
      /// ```
@@ -1657,16 +1536,16 @@ index 12b158e..90064c4 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2028,15 +2013,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -2029,6 +1999,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -2036,7 +2007,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1674,7 +1553,7 @@ index 12b158e..90064c4 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -2063,13 +2042,11 @@ impl<T: BufRead> BufRead for Take<T> {
+@@ -2063,13 +2034,11 @@ impl<T: BufRead> BufRead for Take<T> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1688,7 +1567,7 @@ index 12b158e..90064c4 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -2093,14 +2070,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -2093,14 +2062,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1705,7 +1584,7 @@ index 12b158e..90064c4 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2125,13 +2102,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2125,13 +2094,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines
@@ -1748,9 +1627,9 @@ index 5ce955e..c7d8697 100644
 -use io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 -use mem;
 +use core::fmt;
-+use io::{self, Read, Initializer, Write, ErrorKind};
++use io::{self, Read, Initializer, Write, ErrorKind, IoVec, IoVecMut};
++#[cfg(feature="collections")] use io::BufRead;
 +use core::mem;
-+#[cfg(feature="collections")] use io::{BufRead, IoVec, IoVecMut};
  
  /// Copies the entire contents of a reader into a writer.
  ///
@@ -1818,15 +1697,7 @@ index 5ce955e..c7d8697 100644
  impl Read for Repeat {
      #[inline]
      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-@@ -152,6 +146,7 @@ impl Read for Repeat {
-         Ok(buf.len())
-     }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-         let mut nwritten = 0;
-@@ -167,7 +162,6 @@ impl Read for Repeat {
+@@ -167,7 +161,6 @@ impl Read for Repeat {
      }
  }
  
@@ -1834,7 +1705,7 @@ index 5ce955e..c7d8697 100644
  impl fmt::Debug for Repeat {
      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
          f.pad("Repeat { .. }")
-@@ -180,7 +174,6 @@ impl fmt::Debug for Repeat {
+@@ -180,7 +173,6 @@ impl fmt::Debug for Repeat {
  /// see the documentation of `sink()` for more details.
  ///
  /// [sink]: fn.sink.html
@@ -1842,7 +1713,7 @@ index 5ce955e..c7d8697 100644
  pub struct Sink { _priv: () }
  
  /// Creates an instance of a writer which will successfully consume all data.
-@@ -197,14 +190,13 @@ pub struct Sink { _priv: () }
+@@ -197,10 +189,8 @@ pub struct Sink { _priv: () }
  /// let num_bytes = io::sink().write(&buffer).unwrap();
  /// assert_eq!(num_bytes, 5);
  /// ```
@@ -1853,12 +1724,7 @@ index 5ce955e..c7d8697 100644
  impl Write for Sink {
      #[inline]
      fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
- 
-+    #[cfg(feature="collections")]
-     #[inline]
-     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-         let total_len = bufs.iter().map(|b| b.len()).sum();
-@@ -215,7 +207,6 @@ impl Write for Sink {
+@@ -215,7 +205,6 @@ impl Write for Sink {
      fn flush(&mut self) -> io::Result<()> { Ok(()) }
  }
  

--- a/patches/fc84f5f837a3e1b9b9bc992dd603d3d968502288.patch
+++ b/patches/fc84f5f837a3e1b9b9bc992dd603d3d968502288.patch
@@ -1409,16 +1409,16 @@ index dc97701..6ea0b47 100644
  impl<T: Read> Read for Take<T> {
      fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1907,15 +1856,9 @@ impl<T: Read> Read for Take<T> {
-     unsafe fn initializer(&self) -> Initializer {
+@@ -1908,6 +1857,7 @@ impl<T: Read> Read for Take<T> {
          self.inner.initializer()
      }
--
--    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
--        let reservation_size = cmp::min(self.limit, 32) as usize;
--
--        read_to_end_with_reservation(self, buf, reservation_size)
--    }
+ 
++    #[cfg(feature="collections")]
+     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+         let reservation_size = cmp::min(self.limit, 32) as usize;
+ 
+@@ -1915,7 +1865,7 @@ impl<T: Read> Read for Take<T> {
+     }
  }
  
 -#[stable(feature = "rust1", since = "1.0.0")]
@@ -1426,7 +1426,7 @@ index dc97701..6ea0b47 100644
  impl<T: BufRead> BufRead for Take<T> {
      fn fill_buf(&mut self) -> Result<&[u8]> {
          // Don't call into inner reader at all at EOF because it may still block
-@@ -1954,13 +1897,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
+@@ -1954,13 +1904,11 @@ fn read_one_byte(reader: &mut dyn Read) -> Option<Result<u8>> {
  /// Please see the documentation of [`bytes`] for more details.
  ///
  /// [`bytes`]: trait.Read.html#method.bytes
@@ -1440,7 +1440,7 @@ index dc97701..6ea0b47 100644
  impl<R: Read> Iterator for Bytes<R> {
      type Item = Result<u8>;
  
-@@ -1976,14 +1917,14 @@ impl<R: Read> Iterator for Bytes<R> {
+@@ -1976,14 +1924,14 @@ impl<R: Read> Iterator for Bytes<R> {
  /// `BufRead`. Please see the documentation of `split()` for more details.
  ///
  /// [split]: trait.BufRead.html#method.split
@@ -1457,7 +1457,7 @@ index dc97701..6ea0b47 100644
  impl<B: BufRead> Iterator for Split<B> {
      type Item = Result<Vec<u8>>;
  
-@@ -2008,13 +1949,13 @@ impl<B: BufRead> Iterator for Split<B> {
+@@ -2008,13 +1956,13 @@ impl<B: BufRead> Iterator for Split<B> {
  /// `BufRead`. Please see the documentation of `lines()` for more details.
  ///
  /// [lines]: trait.BufRead.html#method.lines


### PR DESCRIPTION
This is a large PR because I recreated all patches from #18. Contains the following fixes:

- `ioVec` does not depend on `feature="collections"`
- Fix `impl Read for Take`; only `read_to_end` requires `feature="collections"`
- Fix some whitespace consistency issues

Closes #19